### PR TITLE
Change tiered storage cache setting to `none`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 #### Fixed
 #### Removed
 
+### [5.9.17](https://github.com/redpanda-data/helm-charts/releases/tag/redpanda-5.9.17) - 2024-12-17
+#### Added
+#### Changed
+* Default for tiered storage cache to `none` which will defer tiered storage cache path to Redpanda process.
+#### Fixed
+#### Removed
+
 ### [5.9.16](https://github.com/redpanda-data/helm-charts/releases/tag/redpanda-5.9.16) - 2024-12-09
 #### Added
 #### Changed

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.9.16
+version: 5.9.17
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Helm chart.
 ---
 
-![Version: 5.9.16](https://img.shields.io/badge/Version-5.9.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.3.1](https://img.shields.io/badge/AppVersion-v24.3.1-informational?style=flat-square)
+![Version: 5.9.17](https://img.shields.io/badge/Version-5.9.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.3.1](https://img.shields.io/badge/AppVersion-v24.3.1-informational?style=flat-square)
 
 This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -1034,7 +1034,7 @@ Persistence settings. For details, see the [storage documentation](https://docs.
 **Default:**
 
 ```
-{"hostPath":"","persistentVolume":{"annotations":{},"enabled":true,"labels":{},"nameOverwrite":"","size":"20Gi","storageClass":""},"tiered":{"config":{"cloud_storage_cache_size":5368709120,"cloud_storage_enable_remote_read":true,"cloud_storage_enable_remote_write":true,"cloud_storage_enabled":false},"credentialsSecretRef":{"accessKey":{"configurationKey":"cloud_storage_access_key"},"secretKey":{"configurationKey":"cloud_storage_secret_key"}},"hostPath":"","mountType":"emptyDir","persistentVolume":{"annotations":{},"labels":{},"storageClass":""}}}
+{"hostPath":"","persistentVolume":{"annotations":{},"enabled":true,"labels":{},"nameOverwrite":"","size":"20Gi","storageClass":""},"tiered":{"config":{"cloud_storage_cache_size":5368709120,"cloud_storage_enable_remote_read":true,"cloud_storage_enable_remote_write":true,"cloud_storage_enabled":false},"credentialsSecretRef":{"accessKey":{"configurationKey":"cloud_storage_access_key"},"secretKey":{"configurationKey":"cloud_storage_secret_key"}},"hostPath":"","mountType":"none","persistentVolume":{"annotations":{},"labels":{},"storageClass":""}}}
 ```
 
 ### [storage.hostPath](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=storage.hostPath)

--- a/charts/redpanda/testdata/template-cases.golden.txtar
+++ b/charts/redpanda/testdata/template-cases.golden.txtar
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -141,7 +141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -179,7 +179,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -415,7 +415,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -453,7 +453,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -545,7 +545,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -590,7 +590,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -727,7 +727,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -749,7 +749,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -1061,7 +1061,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -1087,7 +1087,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -1113,7 +1113,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1151,7 +1151,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1189,7 +1189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -1205,7 +1205,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -1222,7 +1222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -1238,7 +1238,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -1282,7 +1282,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1383,7 +1383,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
@@ -1422,7 +1422,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     testlabel: exercise_common_labels_template
   name: redpanda-sts-lifecycle
   namespace: default
@@ -1517,7 +1517,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     testlabel: exercise_common_labels_template
   name: redpanda-config-watcher
   namespace: default
@@ -1556,7 +1556,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     testlabel: exercise_common_labels_template
   name: redpanda-configurator
   namespace: default
@@ -1696,7 +1696,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
@@ -1726,7 +1726,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     testlabel: exercise_common_labels_template
   name: redpanda-rpk
   namespace: default
@@ -1815,7 +1815,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     testlabel: exercise_common_labels_template
   name: redpanda-external
   namespace: default
@@ -1861,7 +1861,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
     testlabel: exercise_common_labels_template
   name: redpanda
@@ -1993,7 +1993,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
@@ -2016,7 +2016,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
         testlabel: exercise_common_labels_template
     spec:
@@ -2332,7 +2332,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     testlabel: exercise_common_labels_template
   name: redpanda-configuration
   namespace: default
@@ -2423,7 +2423,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -2461,7 +2461,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -2555,7 +2555,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -2593,7 +2593,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -2796,7 +2796,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -2828,7 +2828,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -2916,7 +2916,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -2961,7 +2961,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -3098,7 +3098,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -3120,7 +3120,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -3432,7 +3432,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -3458,7 +3458,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -3484,7 +3484,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -3522,7 +3522,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -3560,7 +3560,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -3576,7 +3576,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -3593,7 +3593,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -3609,7 +3609,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -3653,7 +3653,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -3754,7 +3754,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -3792,7 +3792,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -3886,7 +3886,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-users
   namespace: default
 stringData:
@@ -3903,7 +3903,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -4040,7 +4040,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -4087,7 +4087,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-bootstrap-user
   namespace: default
 stringData:
@@ -4204,7 +4204,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -4233,7 +4233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -4321,7 +4321,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -4366,7 +4366,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -4512,7 +4512,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -4534,7 +4534,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -4892,7 +4892,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -4998,7 +4998,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -5036,7 +5036,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -5130,7 +5130,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-users
   namespace: default
 stringData:
@@ -5147,7 +5147,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -5284,7 +5284,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -5331,7 +5331,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-bootstrap-user
   namespace: default
 stringData:
@@ -5518,7 +5518,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -5550,7 +5550,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -5638,7 +5638,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -5683,7 +5683,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -5835,7 +5835,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -5857,7 +5857,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -6213,7 +6213,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -6239,7 +6239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -6265,7 +6265,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -6303,7 +6303,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -6341,7 +6341,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -6357,7 +6357,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -6374,7 +6374,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -6390,7 +6390,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -6434,7 +6434,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -6552,7 +6552,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -6592,7 +6592,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -6606,7 +6606,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -6699,7 +6699,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -6737,7 +6737,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -6979,7 +6979,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -7017,7 +7017,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -7084,7 +7084,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
 rules:
 - apiGroups:
@@ -7106,7 +7106,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -7138,7 +7138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7160,7 +7160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7207,7 +7207,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -7252,7 +7252,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -7389,7 +7389,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -7411,7 +7411,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -7744,7 +7744,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -7770,7 +7770,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -7796,7 +7796,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -7834,7 +7834,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -7872,7 +7872,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -7888,7 +7888,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -7905,7 +7905,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -7921,7 +7921,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -7965,7 +7965,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -8066,7 +8066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -8104,7 +8104,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -8197,7 +8197,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -8235,7 +8235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -8531,7 +8531,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -8567,7 +8567,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -8659,7 +8659,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -8734,7 +8734,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -8871,7 +8871,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -8893,7 +8893,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -9229,7 +9229,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-cert2-root-certificate
   namespace: default
 spec:
@@ -9255,7 +9255,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -9281,7 +9281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -9307,7 +9307,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-cert2-cert
   namespace: default
 spec:
@@ -9345,7 +9345,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -9383,7 +9383,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -9421,7 +9421,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-cert2-selfsigned-issuer
   namespace: default
 spec:
@@ -9437,7 +9437,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-cert2-root-issuer
   namespace: default
 spec:
@@ -9454,7 +9454,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -9470,7 +9470,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -9487,7 +9487,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -9503,7 +9503,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -9547,7 +9547,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -9654,7 +9654,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -9692,7 +9692,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -9785,7 +9785,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -9823,7 +9823,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -10059,7 +10059,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -10097,7 +10097,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -10189,7 +10189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -10234,7 +10234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -10371,7 +10371,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -10393,7 +10393,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -10704,7 +10704,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -10730,7 +10730,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -10756,7 +10756,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -10794,7 +10794,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -10832,7 +10832,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -10848,7 +10848,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -10865,7 +10865,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -10881,7 +10881,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -10925,7 +10925,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -11026,7 +11026,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -11064,7 +11064,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -11157,7 +11157,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -11195,7 +11195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -11254,7 +11254,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-fs-validator
   namespace: default
 stringData:
@@ -11486,7 +11486,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -11524,7 +11524,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -11616,7 +11616,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -11661,7 +11661,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -11798,7 +11798,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -11820,7 +11820,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -12220,7 +12220,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -12246,7 +12246,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -12272,7 +12272,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -12310,7 +12310,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -12348,7 +12348,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -12364,7 +12364,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -12381,7 +12381,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -12397,7 +12397,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -12441,7 +12441,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -12542,7 +12542,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -12580,7 +12580,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -12673,7 +12673,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -12711,7 +12711,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -12947,7 +12947,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -12985,7 +12985,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -13077,7 +13077,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -13122,7 +13122,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -13259,7 +13259,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -13281,7 +13281,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -13593,7 +13593,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -13619,7 +13619,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -13645,7 +13645,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -13685,7 +13685,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -13725,7 +13725,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -13741,7 +13741,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -13758,7 +13758,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -13774,7 +13774,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -13818,7 +13818,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -13919,7 +13919,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -13957,7 +13957,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -14050,7 +14050,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: some-users
   namespace: default
 stringData:
@@ -14071,7 +14071,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -14208,7 +14208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -14267,7 +14267,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-bootstrap-user
   namespace: default
 stringData:
@@ -14473,7 +14473,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -14511,7 +14511,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -14603,7 +14603,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -14648,7 +14648,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -14800,7 +14800,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -14822,7 +14822,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -15178,7 +15178,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -15204,7 +15204,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -15230,7 +15230,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -15268,7 +15268,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -15306,7 +15306,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -15322,7 +15322,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -15339,7 +15339,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -15355,7 +15355,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -15399,7 +15399,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -15517,7 +15517,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -15555,7 +15555,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -15648,7 +15648,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -15686,7 +15686,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -15922,7 +15922,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -15960,7 +15960,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -16052,7 +16052,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -16097,7 +16097,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -16234,7 +16234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -16256,7 +16256,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -16568,7 +16568,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -16594,7 +16594,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -16634,7 +16634,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -16650,7 +16650,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -16694,7 +16694,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -16795,7 +16795,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -16833,7 +16833,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -16926,7 +16926,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -16964,7 +16964,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -17200,7 +17200,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -17238,7 +17238,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -17330,7 +17330,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -17376,7 +17376,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     repdanda.com/type: loadbalancer
   name: lb-redpanda-0
   namespace: default
@@ -17420,7 +17420,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     repdanda.com/type: loadbalancer
   name: lb-redpanda-1
   namespace: default
@@ -17464,7 +17464,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     repdanda.com/type: loadbalancer
   name: lb-redpanda-2
   namespace: default
@@ -17599,7 +17599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -17621,7 +17621,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -17933,7 +17933,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -17959,7 +17959,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -17999,7 +17999,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -18015,7 +18015,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -18059,7 +18059,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -18160,7 +18160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -18198,7 +18198,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -18291,7 +18291,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -18329,7 +18329,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -18500,7 +18500,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -18535,7 +18535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -18627,7 +18627,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -18672,7 +18672,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -18803,7 +18803,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -18825,7 +18825,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -19112,7 +19112,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     release: prometheus
   name: redpanda
   namespace: default
@@ -19167,7 +19167,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -19256,7 +19256,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -19294,7 +19294,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -19387,7 +19387,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -19425,7 +19425,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -19661,7 +19661,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -19699,7 +19699,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -19791,7 +19791,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -19836,7 +19836,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -19973,7 +19973,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -19995,7 +19995,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -20307,7 +20307,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -20333,7 +20333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -20359,7 +20359,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -20397,7 +20397,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -20435,7 +20435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -20451,7 +20451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -20468,7 +20468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -20484,7 +20484,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -20501,7 +20501,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     release: prometheus
   name: redpanda
   namespace: default
@@ -20560,7 +20560,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -20661,7 +20661,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -20699,7 +20699,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -20792,7 +20792,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -20830,7 +20830,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -21066,7 +21066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -21104,7 +21104,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -21171,7 +21171,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -21205,7 +21205,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
 rules:
 - apiGroups:
@@ -21227,7 +21227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -21259,7 +21259,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -21281,7 +21281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -21303,7 +21303,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -21325,7 +21325,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -21378,7 +21378,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -21426,7 +21426,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -21471,7 +21471,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -21608,7 +21608,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -21630,7 +21630,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -21980,7 +21980,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -22006,7 +22006,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -22032,7 +22032,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -22070,7 +22070,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -22108,7 +22108,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -22124,7 +22124,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -22141,7 +22141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -22157,7 +22157,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -22201,7 +22201,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -22302,7 +22302,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -22340,7 +22340,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -22433,7 +22433,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -22471,7 +22471,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -22707,7 +22707,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -22745,7 +22745,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -22837,7 +22837,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -22882,7 +22882,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -23019,7 +23019,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -23041,7 +23041,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -23356,7 +23356,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -23382,7 +23382,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -23408,7 +23408,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -23446,7 +23446,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -23484,7 +23484,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -23500,7 +23500,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -23517,7 +23517,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -23533,7 +23533,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -23577,7 +23577,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -23678,7 +23678,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -23716,7 +23716,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -23809,7 +23809,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -23847,7 +23847,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -24083,7 +24083,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -24121,7 +24121,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -24213,7 +24213,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -24258,7 +24258,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -24395,7 +24395,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -24417,7 +24417,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -24729,7 +24729,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -24755,7 +24755,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -24781,7 +24781,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -24821,7 +24821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -24861,7 +24861,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -24877,7 +24877,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -24894,7 +24894,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -24910,7 +24910,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -24954,7 +24954,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -25055,7 +25055,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -25093,7 +25093,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -25186,7 +25186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -25224,7 +25224,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -25504,7 +25504,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -25542,7 +25542,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -25634,7 +25634,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -25679,7 +25679,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -25832,7 +25832,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -25854,7 +25854,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -26181,7 +26181,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -26207,7 +26207,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -26233,7 +26233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -26271,7 +26271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -26309,7 +26309,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -26325,7 +26325,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -26342,7 +26342,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -26358,7 +26358,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -26402,7 +26402,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -26505,7 +26505,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -26543,7 +26543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -26636,7 +26636,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -26674,7 +26674,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -26955,7 +26955,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -26993,7 +26993,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -27085,7 +27085,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -27130,7 +27130,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -27283,7 +27283,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -27305,7 +27305,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -27632,7 +27632,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -27658,7 +27658,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -27684,7 +27684,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -27722,7 +27722,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -27760,7 +27760,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -27776,7 +27776,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -27793,7 +27793,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -27809,7 +27809,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -27853,7 +27853,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -27956,7 +27956,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -27994,7 +27994,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -28087,7 +28087,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -28125,7 +28125,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -28404,7 +28404,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -28442,7 +28442,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -28534,7 +28534,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -28579,7 +28579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -28732,7 +28732,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -28754,7 +28754,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -29082,7 +29082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -29108,7 +29108,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -29134,7 +29134,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -29172,7 +29172,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -29210,7 +29210,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -29226,7 +29226,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -29243,7 +29243,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -29259,7 +29259,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -29303,7 +29303,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -29406,7 +29406,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -29444,7 +29444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -29537,7 +29537,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -29575,7 +29575,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -29816,7 +29816,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -29854,7 +29854,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -29946,7 +29946,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -29991,7 +29991,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -30128,7 +30128,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -30150,7 +30150,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -30478,7 +30478,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -30504,7 +30504,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -30530,7 +30530,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -30568,7 +30568,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -30606,7 +30606,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -30622,7 +30622,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -30639,7 +30639,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -30655,7 +30655,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -30699,7 +30699,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -30800,7 +30800,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -30838,7 +30838,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -30931,7 +30931,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -30969,7 +30969,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -31249,7 +31249,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -31287,7 +31287,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -31379,7 +31379,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -31424,7 +31424,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -31577,7 +31577,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -31599,7 +31599,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -31945,7 +31945,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -31971,7 +31971,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -31997,7 +31997,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -32035,7 +32035,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -32073,7 +32073,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -32089,7 +32089,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -32106,7 +32106,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -32122,7 +32122,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -32166,7 +32166,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -32269,7 +32269,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -32307,7 +32307,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -32400,7 +32400,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -32438,7 +32438,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -32719,7 +32719,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -32757,7 +32757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -32849,7 +32849,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -32894,7 +32894,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -33047,7 +33047,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -33069,7 +33069,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -33415,7 +33415,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -33441,7 +33441,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -33467,7 +33467,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -33505,7 +33505,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -33543,7 +33543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -33559,7 +33559,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -33576,7 +33576,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -33592,7 +33592,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -33636,7 +33636,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -33739,7 +33739,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -33777,7 +33777,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -33870,7 +33870,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -33908,7 +33908,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -34187,7 +34187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -34225,7 +34225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -34317,7 +34317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -34362,7 +34362,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -34515,7 +34515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -34537,7 +34537,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -34885,7 +34885,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -34911,7 +34911,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -34937,7 +34937,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -34975,7 +34975,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -35013,7 +35013,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -35029,7 +35029,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -35046,7 +35046,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -35062,7 +35062,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -35106,7 +35106,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -35209,7 +35209,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -35247,7 +35247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -35340,7 +35340,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -35378,7 +35378,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -35619,7 +35619,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -35657,7 +35657,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -35749,7 +35749,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -35794,7 +35794,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -35931,7 +35931,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -35953,7 +35953,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -36301,7 +36301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -36327,7 +36327,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -36353,7 +36353,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -36391,7 +36391,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -36429,7 +36429,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -36445,7 +36445,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -36462,7 +36462,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -36478,7 +36478,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -36522,7 +36522,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -36623,7 +36623,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -36661,7 +36661,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -36754,7 +36754,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -36792,7 +36792,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -37072,7 +37072,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -37110,7 +37110,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -37202,7 +37202,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -37247,7 +37247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -37400,7 +37400,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -37422,7 +37422,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -37768,7 +37768,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -37794,7 +37794,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -37820,7 +37820,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -37858,7 +37858,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -37896,7 +37896,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -37912,7 +37912,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -37929,7 +37929,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -37945,7 +37945,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -37989,7 +37989,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -38092,7 +38092,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -38130,7 +38130,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -38223,7 +38223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -38261,7 +38261,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -38542,7 +38542,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -38580,7 +38580,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -38672,7 +38672,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -38717,7 +38717,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -38870,7 +38870,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -38892,7 +38892,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -39238,7 +39238,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -39264,7 +39264,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -39290,7 +39290,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -39328,7 +39328,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -39366,7 +39366,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -39382,7 +39382,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -39399,7 +39399,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -39415,7 +39415,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -39459,7 +39459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -39562,7 +39562,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -39600,7 +39600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -39693,7 +39693,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -39731,7 +39731,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -40010,7 +40010,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -40048,7 +40048,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -40140,7 +40140,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -40185,7 +40185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -40338,7 +40338,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -40360,7 +40360,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -40708,7 +40708,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -40734,7 +40734,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -40760,7 +40760,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -40798,7 +40798,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -40836,7 +40836,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -40852,7 +40852,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -40869,7 +40869,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -40885,7 +40885,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -40929,7 +40929,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -41032,7 +41032,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -41070,7 +41070,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -41163,7 +41163,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -41201,7 +41201,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -41442,7 +41442,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -41480,7 +41480,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -41572,7 +41572,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -41617,7 +41617,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -41754,7 +41754,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -41776,7 +41776,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -42124,7 +42124,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -42150,7 +42150,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -42176,7 +42176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -42214,7 +42214,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -42252,7 +42252,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -42268,7 +42268,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -42285,7 +42285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -42301,7 +42301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -42345,7 +42345,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -42446,7 +42446,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -42484,7 +42484,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -42577,7 +42577,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -42615,7 +42615,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -42851,7 +42851,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -42889,7 +42889,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -42981,7 +42981,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -43026,7 +43026,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -43163,7 +43163,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -43185,7 +43185,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -43497,7 +43497,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -43523,7 +43523,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -43549,7 +43549,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -43587,7 +43587,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -43625,7 +43625,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -43641,7 +43641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -43658,7 +43658,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -43674,7 +43674,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -43718,7 +43718,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -43819,7 +43819,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -43857,7 +43857,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -43950,7 +43950,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -43988,7 +43988,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -44224,7 +44224,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -44262,7 +44262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -44354,7 +44354,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -44399,7 +44399,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -44536,7 +44536,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -44559,7 +44559,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
         azure.workload.identity/use: "true"
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -44871,7 +44871,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -44897,7 +44897,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -44923,7 +44923,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -44961,7 +44961,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -44999,7 +44999,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -45015,7 +45015,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -45032,7 +45032,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -45048,7 +45048,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -45092,7 +45092,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -45193,7 +45193,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -45231,7 +45231,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -45324,7 +45324,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -45362,7 +45362,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -45598,7 +45598,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -45636,7 +45636,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -45728,7 +45728,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -45773,7 +45773,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -45910,7 +45910,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -45932,7 +45932,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -46246,7 +46246,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -46272,7 +46272,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -46298,7 +46298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -46336,7 +46336,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -46374,7 +46374,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -46390,7 +46390,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -46407,7 +46407,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -46423,7 +46423,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -46467,7 +46467,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -46568,7 +46568,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -46606,7 +46606,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -46699,7 +46699,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -46737,7 +46737,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -47032,7 +47032,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -47072,7 +47072,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -47166,7 +47166,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -47231,7 +47231,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -47368,7 +47368,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -47390,7 +47390,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -47710,7 +47710,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -47736,7 +47736,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -47762,7 +47762,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -47800,7 +47800,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -47838,7 +47838,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -47854,7 +47854,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -47871,7 +47871,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -47887,7 +47887,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -47931,7 +47931,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -48032,7 +48032,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -48073,7 +48073,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -48166,7 +48166,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -48204,7 +48204,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -48440,7 +48440,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -48478,7 +48478,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -48570,7 +48570,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -48618,7 +48618,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -48758,7 +48758,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -48783,7 +48783,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
         redpanda.com/testing: "true"
         redpanda.com/testing-samples: sample
@@ -49104,7 +49104,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -49130,7 +49130,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -49156,7 +49156,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -49194,7 +49194,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -49232,7 +49232,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -49248,7 +49248,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -49265,7 +49265,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -49281,7 +49281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -49325,7 +49325,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -49426,7 +49426,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -49464,7 +49464,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -49557,7 +49557,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -49595,7 +49595,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -49831,7 +49831,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -49869,7 +49869,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -49936,7 +49936,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -49970,7 +49970,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
 rules:
 - apiGroups:
@@ -49992,7 +49992,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -50024,7 +50024,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -50046,7 +50046,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -50068,7 +50068,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -50090,7 +50090,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -50143,7 +50143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -50191,7 +50191,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -50236,7 +50236,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -50373,7 +50373,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -50395,7 +50395,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -50757,7 +50757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -50783,7 +50783,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -50809,7 +50809,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -50847,7 +50847,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -50885,7 +50885,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -50901,7 +50901,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -50918,7 +50918,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -50934,7 +50934,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -50978,7 +50978,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -51079,7 +51079,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -51117,7 +51117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -51210,7 +51210,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -51248,7 +51248,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -51307,7 +51307,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-fs-validator
   namespace: default
 stringData:
@@ -51539,7 +51539,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -51577,7 +51577,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -51644,7 +51644,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -51678,7 +51678,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -51700,7 +51700,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -51753,7 +51753,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -51801,7 +51801,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -51846,7 +51846,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -51983,7 +51983,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -52005,7 +52005,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -52360,7 +52360,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -52386,7 +52386,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -52412,7 +52412,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -52450,7 +52450,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -52488,7 +52488,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -52504,7 +52504,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -52521,7 +52521,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -52537,7 +52537,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -52581,7 +52581,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -52682,7 +52682,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -52720,7 +52720,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -52813,7 +52813,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -52851,7 +52851,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -53087,7 +53087,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -53125,7 +53125,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -53266,7 +53266,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -53311,7 +53311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -53613,7 +53613,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -53635,7 +53635,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -53947,7 +53947,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -53973,7 +53973,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -53999,7 +53999,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -54037,7 +54037,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -54075,7 +54075,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -54091,7 +54091,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -54108,7 +54108,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -54124,7 +54124,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -54168,7 +54168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -54269,7 +54269,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -54307,7 +54307,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -54400,7 +54400,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -54438,7 +54438,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -54674,7 +54674,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -54712,7 +54712,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -54804,7 +54804,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -54849,7 +54849,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -54986,7 +54986,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -55008,7 +55008,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -55320,7 +55320,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -55346,7 +55346,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -55372,7 +55372,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -55412,7 +55412,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -55452,7 +55452,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -55468,7 +55468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -55485,7 +55485,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -55501,7 +55501,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -55545,7 +55545,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -55646,7 +55646,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -55685,7 +55685,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -55778,7 +55778,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -55816,7 +55816,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -56052,7 +56052,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -56090,7 +56090,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -56182,7 +56182,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: change-name-external
   namespace: default
 spec:
@@ -56229,7 +56229,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "true"
   name: change-name
   namespace: default
@@ -56367,7 +56367,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -56390,7 +56390,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
         test: test
     spec:
@@ -56705,7 +56705,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -56731,7 +56731,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -56757,7 +56757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -56795,7 +56795,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -56833,7 +56833,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -56849,7 +56849,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -56866,7 +56866,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -56882,7 +56882,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -56899,7 +56899,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -56957,7 +56957,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -57058,7 +57058,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -57096,7 +57096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -57189,7 +57189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -57227,7 +57227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -57463,7 +57463,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -57501,7 +57501,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -57593,7 +57593,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -57638,7 +57638,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -57775,7 +57775,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -57797,7 +57797,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -58124,7 +58124,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -58150,7 +58150,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -58176,7 +58176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -58214,7 +58214,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -58252,7 +58252,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -58268,7 +58268,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -58285,7 +58285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -58301,7 +58301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -58345,7 +58345,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -58465,7 +58465,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -58503,7 +58503,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -58596,7 +58596,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -58634,7 +58634,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -58870,7 +58870,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -58908,7 +58908,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -59000,7 +59000,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -59045,7 +59045,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -59182,7 +59182,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -59204,7 +59204,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -59531,7 +59531,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -59557,7 +59557,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -59583,7 +59583,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -59621,7 +59621,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -59659,7 +59659,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -59675,7 +59675,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -59692,7 +59692,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -59708,7 +59708,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -59752,7 +59752,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -59874,7 +59874,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -59912,7 +59912,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -60005,7 +60005,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -60043,7 +60043,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -60279,7 +60279,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -60317,7 +60317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -60409,7 +60409,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -60454,7 +60454,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -60591,7 +60591,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -60613,7 +60613,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -60928,7 +60928,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -60954,7 +60954,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -60980,7 +60980,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -61018,7 +61018,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -61056,7 +61056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -61072,7 +61072,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -61089,7 +61089,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -61105,7 +61105,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -61149,7 +61149,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -61253,7 +61253,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -61275,7 +61275,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -61368,7 +61368,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -61406,7 +61406,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -61624,7 +61624,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -61663,7 +61663,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -61678,7 +61678,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -61723,7 +61723,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -61768,7 +61768,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -61790,7 +61790,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -62116,7 +62116,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -62142,7 +62142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -62168,7 +62168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-kafka-internal-0-root-certificate
   namespace: default
 spec:
@@ -62194,7 +62194,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -62232,7 +62232,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -62270,7 +62270,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-kafka-internal-0-cert
   namespace: default
 spec:
@@ -62308,7 +62308,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-client
 spec:
   commonName: redpanda-client
@@ -62333,7 +62333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -62349,7 +62349,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -62366,7 +62366,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -62382,7 +62382,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -62399,7 +62399,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-kafka-internal-0-selfsigned-issuer
   namespace: default
 spec:
@@ -62415,7 +62415,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-kafka-internal-0-root-issuer
   namespace: default
 spec:
@@ -62436,7 +62436,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -62543,7 +62543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -62581,7 +62581,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -62674,7 +62674,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -62712,7 +62712,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -62948,7 +62948,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -62986,7 +62986,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -63078,7 +63078,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -63123,7 +63123,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -63260,7 +63260,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -63282,7 +63282,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -63594,7 +63594,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -63620,7 +63620,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -63646,7 +63646,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -63672,7 +63672,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -63698,7 +63698,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -63715,7 +63715,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -63759,7 +63759,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -63860,7 +63860,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -63898,7 +63898,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -63991,7 +63991,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-users
   namespace: default
 stringData:
@@ -64008,7 +64008,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -64145,7 +64145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -64204,7 +64204,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-bootstrap-user
   namespace: default
 stringData:
@@ -64458,7 +64458,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -64496,7 +64496,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -64588,7 +64588,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -64633,7 +64633,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -64801,7 +64801,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -64823,7 +64823,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -65179,7 +65179,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -65205,7 +65205,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -65231,7 +65231,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -65269,7 +65269,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -65307,7 +65307,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -65323,7 +65323,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -65340,7 +65340,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -65356,7 +65356,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -65400,7 +65400,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -65520,7 +65520,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -65558,7 +65558,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -65651,7 +65651,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -65689,7 +65689,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -65963,7 +65963,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -66001,7 +66001,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -66093,7 +66093,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -66138,7 +66138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -66291,7 +66291,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -66313,7 +66313,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -66625,7 +66625,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -66651,7 +66651,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -66677,7 +66677,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -66715,7 +66715,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -66753,7 +66753,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -66769,7 +66769,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -66786,7 +66786,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -66802,7 +66802,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -66846,7 +66846,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -66949,7 +66949,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -66987,7 +66987,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -67080,7 +67080,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -67118,7 +67118,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -67354,7 +67354,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -67392,7 +67392,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -67484,7 +67484,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -67529,7 +67529,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -67671,7 +67671,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -67693,7 +67693,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -68005,7 +68005,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -68031,7 +68031,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -68057,7 +68057,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -68095,7 +68095,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -68133,7 +68133,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -68149,7 +68149,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -68166,7 +68166,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -68182,7 +68182,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -68226,7 +68226,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -68332,7 +68332,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -68370,7 +68370,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -68463,7 +68463,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -68501,7 +68501,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -68737,7 +68737,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -68775,7 +68775,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -68916,7 +68916,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -68961,7 +68961,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -69290,7 +69290,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -69312,7 +69312,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -69652,7 +69652,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -69678,7 +69678,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -69704,7 +69704,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -69742,7 +69742,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -69780,7 +69780,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -69796,7 +69796,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -69813,7 +69813,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -69829,7 +69829,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -69895,7 +69895,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -69996,7 +69996,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -70034,7 +70034,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -70127,7 +70127,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -70165,7 +70165,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -70401,7 +70401,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -70439,7 +70439,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -70531,7 +70531,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -70576,7 +70576,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -70713,7 +70713,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -70735,7 +70735,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -71048,7 +71048,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -71074,7 +71074,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -71100,7 +71100,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -71138,7 +71138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -71176,7 +71176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -71192,7 +71192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -71209,7 +71209,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -71225,7 +71225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -71269,7 +71269,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -71371,7 +71371,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -71409,7 +71409,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -71502,7 +71502,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -71540,7 +71540,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -71776,7 +71776,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -71814,7 +71814,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -71906,7 +71906,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -71951,7 +71951,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -72088,7 +72088,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -72110,7 +72110,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -72423,7 +72423,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -72449,7 +72449,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -72475,7 +72475,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -72513,7 +72513,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -72551,7 +72551,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -72567,7 +72567,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -72584,7 +72584,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -72600,7 +72600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -72644,7 +72644,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -72746,7 +72746,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -72784,7 +72784,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -72877,7 +72877,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -72915,7 +72915,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -73151,7 +73151,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -73189,7 +73189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -73281,7 +73281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -73326,7 +73326,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -73463,7 +73463,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -73485,7 +73485,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -73797,7 +73797,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -73823,7 +73823,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -73849,7 +73849,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -73887,7 +73887,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -73925,7 +73925,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -73941,7 +73941,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -73958,7 +73958,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -73974,7 +73974,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -74018,7 +74018,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -74119,7 +74119,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -74157,7 +74157,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -74250,7 +74250,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -74288,7 +74288,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -74524,7 +74524,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -74562,7 +74562,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -74654,7 +74654,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -74699,7 +74699,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -74843,7 +74843,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -74865,7 +74865,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -75177,7 +75177,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -75203,7 +75203,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -75229,7 +75229,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -75267,7 +75267,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -75305,7 +75305,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -75321,7 +75321,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -75338,7 +75338,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -75354,7 +75354,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -75398,7 +75398,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -76858,7 +76858,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -76896,7 +76896,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -76989,7 +76989,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-users
   namespace: default
 stringData:
@@ -77009,7 +77009,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -77146,7 +77146,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -77205,7 +77205,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-bootstrap-user
   namespace: default
 stringData:
@@ -77410,7 +77410,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -77448,7 +77448,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -77540,7 +77540,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -77585,7 +77585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -77737,7 +77737,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -77759,7 +77759,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -78115,7 +78115,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -78141,7 +78141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -78167,7 +78167,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -78205,7 +78205,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -78243,7 +78243,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -78259,7 +78259,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -78276,7 +78276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -78292,7 +78292,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -78336,7 +78336,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -78478,7 +78478,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -78516,7 +78516,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -78609,7 +78609,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -78647,7 +78647,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -78883,7 +78883,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -78921,7 +78921,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -79013,7 +79013,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -79058,7 +79058,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -79195,7 +79195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -79217,7 +79217,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -79529,7 +79529,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -79555,7 +79555,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -79581,7 +79581,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -79619,7 +79619,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -79657,7 +79657,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -79673,7 +79673,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -79690,7 +79690,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -79706,7 +79706,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -79750,7 +79750,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -79851,7 +79851,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -79889,7 +79889,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -79982,7 +79982,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -80020,7 +80020,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -80293,7 +80293,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -80331,7 +80331,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -80423,7 +80423,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -80468,7 +80468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -80621,7 +80621,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -80643,7 +80643,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -80955,7 +80955,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -80981,7 +80981,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -81007,7 +81007,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -81045,7 +81045,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -81083,7 +81083,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -81099,7 +81099,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -81116,7 +81116,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -81132,7 +81132,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -81176,7 +81176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -81279,7 +81279,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -81317,7 +81317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -81410,7 +81410,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -81448,7 +81448,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -81689,7 +81689,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -81727,7 +81727,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -81819,7 +81819,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -81864,7 +81864,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -82001,7 +82001,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -82023,7 +82023,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -82356,7 +82356,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -82382,7 +82382,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -82408,7 +82408,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -82446,7 +82446,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -82484,7 +82484,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -82500,7 +82500,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -82517,7 +82517,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -82533,7 +82533,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -82577,7 +82577,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -82690,7 +82690,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -82728,7 +82728,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -82821,7 +82821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -82859,7 +82859,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -83095,7 +83095,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -83133,7 +83133,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -83225,7 +83225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -83270,7 +83270,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -83407,7 +83407,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -83429,7 +83429,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -83741,7 +83741,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -83767,7 +83767,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -83793,7 +83793,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -83831,7 +83831,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -83869,7 +83869,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -83885,7 +83885,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -83902,7 +83902,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -83918,7 +83918,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -83962,7 +83962,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -84063,7 +84063,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -84101,7 +84101,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -84194,7 +84194,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -84232,7 +84232,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -84505,7 +84505,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -84543,7 +84543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -84635,7 +84635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -84680,7 +84680,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -84833,7 +84833,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -84855,7 +84855,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -85167,7 +85167,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -85193,7 +85193,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -85219,7 +85219,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -85257,7 +85257,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -85295,7 +85295,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -85311,7 +85311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -85328,7 +85328,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -85344,7 +85344,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -85388,7 +85388,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -85491,7 +85491,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -85529,7 +85529,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -85622,7 +85622,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -85660,7 +85660,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -85901,7 +85901,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -85939,7 +85939,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -86031,7 +86031,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -86076,7 +86076,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -86213,7 +86213,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -86235,7 +86235,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -86568,7 +86568,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -86594,7 +86594,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -86620,7 +86620,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -86658,7 +86658,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -86696,7 +86696,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -86712,7 +86712,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -86729,7 +86729,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -86745,7 +86745,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -86789,7 +86789,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -86890,7 +86890,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -86928,7 +86928,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -87021,7 +87021,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -87059,7 +87059,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -87295,7 +87295,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -87333,7 +87333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -87425,7 +87425,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -87470,7 +87470,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -87607,7 +87607,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -87629,7 +87629,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -87941,7 +87941,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -87967,7 +87967,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -87993,7 +87993,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -88031,7 +88031,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -88069,7 +88069,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -88085,7 +88085,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -88102,7 +88102,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -88118,7 +88118,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -88162,7 +88162,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -88263,7 +88263,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -88301,7 +88301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -88394,7 +88394,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -88432,7 +88432,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -88705,7 +88705,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -88743,7 +88743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -88835,7 +88835,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -88880,7 +88880,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -89033,7 +89033,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -89055,7 +89055,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -89367,7 +89367,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -89393,7 +89393,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -89419,7 +89419,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -89457,7 +89457,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -89495,7 +89495,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -89511,7 +89511,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -89528,7 +89528,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -89544,7 +89544,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -89588,7 +89588,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -89691,7 +89691,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -89729,7 +89729,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -89822,7 +89822,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -89860,7 +89860,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -90101,7 +90101,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -90139,7 +90139,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -90231,7 +90231,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -90276,7 +90276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -90413,7 +90413,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -90435,7 +90435,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -90768,7 +90768,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -90794,7 +90794,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -90820,7 +90820,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -90858,7 +90858,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -90896,7 +90896,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -90912,7 +90912,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -90929,7 +90929,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -90945,7 +90945,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -90989,7 +90989,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -91090,7 +91090,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -91128,7 +91128,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -91221,7 +91221,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -91259,7 +91259,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -91495,7 +91495,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -91533,7 +91533,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -91625,7 +91625,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -91670,7 +91670,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -91807,7 +91807,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -91829,7 +91829,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -92141,7 +92141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -92167,7 +92167,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -92193,7 +92193,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -92231,7 +92231,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -92269,7 +92269,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -92285,7 +92285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -92302,7 +92302,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -92318,7 +92318,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -92362,7 +92362,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -92463,7 +92463,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -92501,7 +92501,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -92594,7 +92594,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -92632,7 +92632,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -92905,7 +92905,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -92943,7 +92943,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -93035,7 +93035,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -93080,7 +93080,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -93233,7 +93233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -93255,7 +93255,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -93567,7 +93567,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -93593,7 +93593,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -93619,7 +93619,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -93657,7 +93657,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -93695,7 +93695,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -93711,7 +93711,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -93728,7 +93728,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -93744,7 +93744,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -93788,7 +93788,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -93891,7 +93891,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -93929,7 +93929,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -94022,7 +94022,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -94060,7 +94060,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -94301,7 +94301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -94339,7 +94339,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -94431,7 +94431,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -94476,7 +94476,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -94613,7 +94613,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -94635,7 +94635,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -94968,7 +94968,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -94994,7 +94994,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -95020,7 +95020,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -95058,7 +95058,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -95096,7 +95096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -95112,7 +95112,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -95129,7 +95129,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -95145,7 +95145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -95189,7 +95189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -95290,7 +95290,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -95328,7 +95328,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -95421,7 +95421,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -95459,7 +95459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -95696,7 +95696,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -95734,7 +95734,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -95826,7 +95826,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -95871,7 +95871,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -96008,7 +96008,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -96030,7 +96030,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -96342,7 +96342,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -96368,7 +96368,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -96394,7 +96394,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -96432,7 +96432,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -96470,7 +96470,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -96486,7 +96486,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -96503,7 +96503,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -96519,7 +96519,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -96563,7 +96563,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -96664,7 +96664,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -96702,7 +96702,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -96795,7 +96795,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -96833,7 +96833,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -97107,7 +97107,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -97145,7 +97145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -97237,7 +97237,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -97282,7 +97282,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -97435,7 +97435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -97457,7 +97457,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -97769,7 +97769,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -97795,7 +97795,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -97821,7 +97821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -97859,7 +97859,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -97897,7 +97897,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -97913,7 +97913,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -97930,7 +97930,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -97946,7 +97946,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -97990,7 +97990,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -98093,7 +98093,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -98131,7 +98131,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -98224,7 +98224,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -98262,7 +98262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -98504,7 +98504,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -98542,7 +98542,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -98634,7 +98634,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -98679,7 +98679,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -98816,7 +98816,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -98838,7 +98838,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -99171,7 +99171,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -99197,7 +99197,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -99223,7 +99223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -99261,7 +99261,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -99299,7 +99299,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -99315,7 +99315,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -99332,7 +99332,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -99348,7 +99348,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -99392,7 +99392,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -99493,7 +99493,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -99531,7 +99531,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -99624,7 +99624,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -99662,7 +99662,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -99899,7 +99899,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -99937,7 +99937,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -100029,7 +100029,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -100074,7 +100074,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -100211,7 +100211,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -100233,7 +100233,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -100545,7 +100545,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -100571,7 +100571,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -100597,7 +100597,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -100635,7 +100635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -100673,7 +100673,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -100689,7 +100689,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -100706,7 +100706,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -100722,7 +100722,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -100766,7 +100766,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -100867,7 +100867,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -100905,7 +100905,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -100998,7 +100998,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -101036,7 +101036,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -101310,7 +101310,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -101348,7 +101348,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -101440,7 +101440,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -101485,7 +101485,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -101638,7 +101638,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -101660,7 +101660,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -101972,7 +101972,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -101998,7 +101998,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -102024,7 +102024,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -102062,7 +102062,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -102100,7 +102100,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -102116,7 +102116,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -102133,7 +102133,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -102149,7 +102149,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -102193,7 +102193,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -102296,7 +102296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -102334,7 +102334,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -102427,7 +102427,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -102465,7 +102465,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -102707,7 +102707,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -102745,7 +102745,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -102837,7 +102837,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -102882,7 +102882,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -103019,7 +103019,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -103041,7 +103041,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -103374,7 +103374,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -103400,7 +103400,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -103426,7 +103426,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -103464,7 +103464,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -103502,7 +103502,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -103518,7 +103518,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -103535,7 +103535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -103551,7 +103551,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -103595,7 +103595,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -103696,7 +103696,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -103734,7 +103734,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -103827,7 +103827,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -103865,7 +103865,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -104101,7 +104101,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -104139,7 +104139,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -104231,7 +104231,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -104276,7 +104276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -104413,7 +104413,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -104435,7 +104435,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -104774,7 +104774,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -104875,7 +104875,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -104913,7 +104913,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -105006,7 +105006,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -105044,7 +105044,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -105280,7 +105280,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -105318,7 +105318,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -105410,7 +105410,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -105455,7 +105455,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -105598,7 +105598,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -105620,7 +105620,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -105959,7 +105959,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -106060,7 +106060,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -106100,7 +106100,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -106114,7 +106114,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -106207,7 +106207,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -106245,7 +106245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -106481,7 +106481,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -106519,7 +106519,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -106586,7 +106586,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -106620,7 +106620,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
 rules:
 - apiGroups:
@@ -106642,7 +106642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -106674,7 +106674,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -106696,7 +106696,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -106718,7 +106718,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -106740,7 +106740,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -106793,7 +106793,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -106841,7 +106841,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -106886,7 +106886,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -107023,7 +107023,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -107045,7 +107045,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -107395,7 +107395,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -107421,7 +107421,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -107447,7 +107447,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -107485,7 +107485,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -107523,7 +107523,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -107539,7 +107539,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -107556,7 +107556,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -107572,7 +107572,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -107616,7 +107616,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -107717,7 +107717,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -107755,7 +107755,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -107848,7 +107848,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -107886,7 +107886,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -108122,7 +108122,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -108160,7 +108160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -108301,7 +108301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -108346,7 +108346,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -108648,7 +108648,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -108670,7 +108670,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -108982,7 +108982,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -109008,7 +109008,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -109034,7 +109034,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -109072,7 +109072,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -109110,7 +109110,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -109126,7 +109126,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -109143,7 +109143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -109159,7 +109159,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -109203,7 +109203,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -109304,7 +109304,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -109344,7 +109344,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -109358,7 +109358,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -109451,7 +109451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -109489,7 +109489,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -109725,7 +109725,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -109763,7 +109763,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -109830,7 +109830,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -109864,7 +109864,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
 rules:
 - apiGroups:
@@ -109886,7 +109886,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -109918,7 +109918,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -109940,7 +109940,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -109962,7 +109962,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -109984,7 +109984,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -110037,7 +110037,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -110085,7 +110085,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -110130,7 +110130,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -110267,7 +110267,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -110289,7 +110289,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -110618,7 +110618,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -110644,7 +110644,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -110670,7 +110670,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -110708,7 +110708,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -110746,7 +110746,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -110762,7 +110762,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -110779,7 +110779,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -110795,7 +110795,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -110839,7 +110839,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -110940,7 +110940,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -110980,7 +110980,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -110994,7 +110994,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -111087,7 +111087,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -111125,7 +111125,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -111361,7 +111361,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -111399,7 +111399,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -111466,7 +111466,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -111500,7 +111500,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
 rules:
 - apiGroups:
@@ -111522,7 +111522,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -111554,7 +111554,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -111576,7 +111576,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -111598,7 +111598,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -111620,7 +111620,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -111673,7 +111673,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -111721,7 +111721,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -111766,7 +111766,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -111903,7 +111903,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -111925,7 +111925,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -112276,7 +112276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -112302,7 +112302,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -112328,7 +112328,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -112366,7 +112366,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -112404,7 +112404,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -112420,7 +112420,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -112437,7 +112437,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -112453,7 +112453,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -112497,7 +112497,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -112598,7 +112598,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -112636,7 +112636,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -112729,7 +112729,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -112767,7 +112767,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -112826,7 +112826,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-fs-validator
   namespace: default
 stringData:
@@ -113058,7 +113058,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -113096,7 +113096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -113188,7 +113188,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -113233,7 +113233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -113370,7 +113370,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -113392,7 +113392,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -113774,7 +113774,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -113800,7 +113800,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -113826,7 +113826,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -113864,7 +113864,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -113902,7 +113902,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -113918,7 +113918,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -113935,7 +113935,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -113951,7 +113951,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -113995,7 +113995,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -114096,7 +114096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -114134,7 +114134,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -114227,7 +114227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -114265,7 +114265,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -114501,7 +114501,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -114539,7 +114539,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -114631,7 +114631,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -114678,7 +114678,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     repdanda.com/type: loadbalancer
   name: lb-redpanda-0
   namespace: default
@@ -114723,7 +114723,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     repdanda.com/type: loadbalancer
   name: lb-redpanda-1
   namespace: default
@@ -114768,7 +114768,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     repdanda.com/type: loadbalancer
   name: lb-redpanda-2
   namespace: default
@@ -114903,7 +114903,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -114925,7 +114925,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -115237,7 +115237,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -115263,7 +115263,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -115289,7 +115289,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -115329,7 +115329,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -115369,7 +115369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -115385,7 +115385,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -115402,7 +115402,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -115418,7 +115418,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -115462,7 +115462,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -115563,7 +115563,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -115601,7 +115601,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -115694,7 +115694,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -115732,7 +115732,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -115968,7 +115968,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -116006,7 +116006,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -116098,7 +116098,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -116145,7 +116145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     repdanda.com/type: loadbalancer
   name: lb-redpanda-0
   namespace: default
@@ -116190,7 +116190,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     repdanda.com/type: loadbalancer
   name: lb-redpanda-1
   namespace: default
@@ -116235,7 +116235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     repdanda.com/type: loadbalancer
   name: lb-redpanda-2
   namespace: default
@@ -116370,7 +116370,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -116392,7 +116392,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -116704,7 +116704,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -116730,7 +116730,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -116756,7 +116756,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -116796,7 +116796,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -116836,7 +116836,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -116852,7 +116852,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -116869,7 +116869,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -116885,7 +116885,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -116929,7 +116929,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -117030,7 +117030,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -117068,7 +117068,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -117161,7 +117161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -117199,7 +117199,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -117497,7 +117497,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -117535,7 +117535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -117627,7 +117627,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -117692,7 +117692,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -117866,7 +117866,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -117888,7 +117888,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -118245,7 +118245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -118271,7 +118271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -118297,7 +118297,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -118335,7 +118335,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -118373,7 +118373,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -118389,7 +118389,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -118406,7 +118406,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -118422,7 +118422,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -118466,7 +118466,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -118567,7 +118567,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -118605,7 +118605,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -118698,7 +118698,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -118736,7 +118736,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -118979,7 +118979,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -119019,7 +119019,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -119111,7 +119111,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -119156,7 +119156,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -119299,7 +119299,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -119321,7 +119321,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -119645,7 +119645,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -119671,7 +119671,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -119697,7 +119697,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-kafka-internal-0-root-certificate
   namespace: default
 spec:
@@ -119723,7 +119723,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -119761,7 +119761,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -119799,7 +119799,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-kafka-internal-0-cert
   namespace: default
 spec:
@@ -119837,7 +119837,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-client
 spec:
   commonName: redpanda-client
@@ -119862,7 +119862,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -119878,7 +119878,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -119895,7 +119895,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -119911,7 +119911,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -119928,7 +119928,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-kafka-internal-0-selfsigned-issuer
   namespace: default
 spec:
@@ -119944,7 +119944,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-kafka-internal-0-root-issuer
   namespace: default
 spec:
@@ -119988,7 +119988,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -120095,7 +120095,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -120133,7 +120133,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -120226,7 +120226,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -120264,7 +120264,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -120500,7 +120500,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -120538,7 +120538,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -120630,7 +120630,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -120675,7 +120675,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -120812,7 +120812,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -120834,7 +120834,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -121146,7 +121146,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -121172,7 +121172,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -121198,7 +121198,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -121236,7 +121236,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -121274,7 +121274,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -121290,7 +121290,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -121307,7 +121307,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -121323,7 +121323,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -121367,7 +121367,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -121468,7 +121468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -121506,7 +121506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -121599,7 +121599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -121637,7 +121637,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -121873,7 +121873,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -121911,7 +121911,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -122003,7 +122003,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -122048,7 +122048,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -122185,7 +122185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -122207,7 +122207,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -122519,7 +122519,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -122545,7 +122545,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -122571,7 +122571,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -122609,7 +122609,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -122647,7 +122647,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -122663,7 +122663,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -122680,7 +122680,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -122696,7 +122696,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -122713,7 +122713,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -122771,7 +122771,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -122872,7 +122872,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -122910,7 +122910,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -123003,7 +123003,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -123041,7 +123041,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -123264,7 +123264,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -123301,7 +123301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -123393,7 +123393,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -123438,7 +123438,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -123575,7 +123575,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -123597,7 +123597,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -123908,7 +123908,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -123934,7 +123934,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -123960,7 +123960,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -123998,7 +123998,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -124036,7 +124036,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -124052,7 +124052,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -124069,7 +124069,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -124085,7 +124085,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -124102,7 +124102,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -124156,7 +124156,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -124257,7 +124257,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -124295,7 +124295,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -124388,7 +124388,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -124426,7 +124426,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -124662,7 +124662,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -124700,7 +124700,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -124792,7 +124792,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -124837,7 +124837,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -124974,7 +124974,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -124996,7 +124996,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -125308,7 +125308,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -125334,7 +125334,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -125360,7 +125360,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -125398,7 +125398,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -125436,7 +125436,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -125452,7 +125452,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -125469,7 +125469,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -125485,7 +125485,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -125529,7 +125529,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -125630,7 +125630,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -125668,7 +125668,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -125761,7 +125761,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -125799,7 +125799,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -126072,7 +126072,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -126110,7 +126110,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -126202,7 +126202,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -126247,7 +126247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -126400,7 +126400,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -126422,7 +126422,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -126734,7 +126734,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -126760,7 +126760,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -126786,7 +126786,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -126824,7 +126824,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -126862,7 +126862,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -126878,7 +126878,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -126895,7 +126895,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -126911,7 +126911,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -126955,7 +126955,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -127058,7 +127058,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -127096,7 +127096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -127189,7 +127189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -127227,7 +127227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -127468,7 +127468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -127506,7 +127506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -127598,7 +127598,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -127643,7 +127643,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -127780,7 +127780,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -127802,7 +127802,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -128135,7 +128135,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -128161,7 +128161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -128187,7 +128187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -128225,7 +128225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -128263,7 +128263,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -128279,7 +128279,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -128296,7 +128296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -128312,7 +128312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -128356,7 +128356,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -128457,7 +128457,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -128495,7 +128495,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -128588,7 +128588,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -128626,7 +128626,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -128863,7 +128863,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -128901,7 +128901,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -128993,7 +128993,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -129038,7 +129038,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -129175,7 +129175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -129197,7 +129197,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -129509,7 +129509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -129535,7 +129535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -129561,7 +129561,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -129599,7 +129599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -129637,7 +129637,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -129653,7 +129653,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -129670,7 +129670,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -129686,7 +129686,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -129730,7 +129730,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -129831,7 +129831,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -129869,7 +129869,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -129962,7 +129962,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -130000,7 +130000,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -130274,7 +130274,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -130312,7 +130312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -130404,7 +130404,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -130449,7 +130449,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -130602,7 +130602,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -130624,7 +130624,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -130936,7 +130936,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -130962,7 +130962,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -130988,7 +130988,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -131026,7 +131026,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -131064,7 +131064,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -131080,7 +131080,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -131097,7 +131097,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -131113,7 +131113,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -131157,7 +131157,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -131260,7 +131260,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -131298,7 +131298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -131391,7 +131391,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -131429,7 +131429,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -131671,7 +131671,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -131709,7 +131709,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -131801,7 +131801,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -131846,7 +131846,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -131983,7 +131983,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -132005,7 +132005,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -132338,7 +132338,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -132364,7 +132364,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -132390,7 +132390,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -132428,7 +132428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -132466,7 +132466,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -132482,7 +132482,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -132499,7 +132499,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -132515,7 +132515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -132559,7 +132559,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -132660,7 +132660,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -132698,7 +132698,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -132791,7 +132791,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -132829,7 +132829,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -133065,7 +133065,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -133103,7 +133103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -133205,7 +133205,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -133250,7 +133250,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -133394,7 +133394,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -133416,7 +133416,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -133756,7 +133756,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -133782,7 +133782,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -133808,7 +133808,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -133846,7 +133846,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -133884,7 +133884,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -133900,7 +133900,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -133917,7 +133917,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -133933,7 +133933,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -133977,7 +133977,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:
@@ -134078,7 +134078,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -134116,7 +134116,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -134209,7 +134209,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -134247,7 +134247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -134483,7 +134483,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 ---
@@ -134521,7 +134521,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-rpk
   namespace: default
 ---
@@ -134613,7 +134613,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external
   namespace: default
 spec:
@@ -134658,7 +134658,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -134795,7 +134795,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda
   namespace: default
 spec:
@@ -134817,7 +134817,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.16
+        helm.sh/chart: redpanda-5.9.17
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -135129,7 +135129,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -135155,7 +135155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -135181,7 +135181,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -135219,7 +135219,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -135257,7 +135257,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -135273,7 +135273,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -135290,7 +135290,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -135306,7 +135306,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -135350,7 +135350,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.16
+    helm.sh/chart: redpanda-5.9.17
   name: redpanda-configuration
   namespace: default
 spec:

--- a/charts/redpanda/testdata/template-cases.golden.txtar
+++ b/charts/redpanda/testdata/template-cases.golden.txtar
@@ -25980,8 +25980,6 @@ spec:
           name: lifecycle-scripts
         - mountPath: /var/lib/redpanda/data
           name: datadir
-        - mountPath: /var/lib/redpanda/data/cloud_storage_cache
-          name: tiered-storage-dir
       - args:
         - -c
         - trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh
@@ -26040,8 +26038,6 @@ spec:
           name: redpanda-external-cert
         - mountPath: /var/lib/redpanda/data
           name: datadir
-        - mountPath: /var/lib/redpanda/data/cloud_storage_cache
-          name: tiered-storage-dir
       - command:
         - /bin/bash
         - -c
@@ -26156,9 +26152,6 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
-      - emptyDir:
-          sizeLimit: 5368709120
-        name: tiered-storage-dir
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -27438,8 +27431,6 @@ spec:
           name: lifecycle-scripts
         - mountPath: /var/lib/redpanda/data
           name: datadir
-        - mountPath: /var/lib/redpanda/data/cloud_storage_cache
-          name: tiered-storage-dir
       - args:
         - -c
         - trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh
@@ -27498,8 +27489,6 @@ spec:
           name: redpanda-external-cert
         - mountPath: /var/lib/redpanda/data
           name: datadir
-        - mountPath: /var/lib/redpanda/data/cloud_storage_cache
-          name: tiered-storage-dir
       - command:
         - /bin/bash
         - -c
@@ -27614,9 +27603,6 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
-      - emptyDir:
-          sizeLimit: 5368709120
-        name: tiered-storage-dir
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -28894,8 +28880,6 @@ spec:
           name: lifecycle-scripts
         - mountPath: /var/lib/redpanda/data
           name: datadir
-        - mountPath: /var/lib/redpanda/data/cloud_storage_cache
-          name: tiered-storage-dir
       - args:
         - -c
         - trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh
@@ -28954,8 +28938,6 @@ spec:
           name: redpanda-external-cert
         - mountPath: /var/lib/redpanda/data
           name: datadir
-        - mountPath: /var/lib/redpanda/data/cloud_storage_cache
-          name: tiered-storage-dir
       - command:
         - /bin/bash
         - -c
@@ -29070,9 +29052,6 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
-      - emptyDir:
-          sizeLimit: 5368709120
-        name: tiered-storage-dir
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -30297,8 +30276,6 @@ spec:
           name: lifecycle-scripts
         - mountPath: /var/lib/redpanda/data
           name: datadir
-        - mountPath: /var/lib/redpanda/data/cloud_storage_cache
-          name: tiered-storage-dir
       - args:
         - -c
         - trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh
@@ -30357,8 +30334,6 @@ spec:
           name: redpanda-external-cert
         - mountPath: /var/lib/redpanda/data
           name: datadir
-        - mountPath: /var/lib/redpanda/data/cloud_storage_cache
-          name: tiered-storage-dir
       - command:
         - /bin/bash
         - -c
@@ -30473,9 +30448,6 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
-      - emptyDir:
-          sizeLimit: 5368709120
-        name: tiered-storage-dir
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -479,7 +479,7 @@ storage:
     # - hostPath: will allow you to chose a path on the Node the pod is running on
     # - emptyDir: will mount a fresh empty directory every time the pod starts
     # - persistentVolume: creates and mounts a PersistentVolumeClaim
-    mountType: emptyDir
+    mountType: none
 
     # For the maximum size of the disk cache, see `tieredConfig.cloud_storage_cache_size`.
     #


### PR DESCRIPTION
Set default value for tiered storage cache to `none` which will defer tiered
storage cache path to Redpanda process. Previously the `emptyDir` volume could
fill Kubernetes VM quickly and tip over such K8S Node. Then user would need to
restart Pod to clean the content of the `emptyDir` volume.

[K8S-147]

[K8S-147]: https://redpandadata.atlassian.net/browse/K8S-147

Fixes #1176 