### PR TITLE
Redpanda 5.9.18 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 #### Fixed
 #### Removed
 
+### [5.9.18](https://github.com/redpanda-data/helm-charts/releases/tag/redpanda-5.9.18) - 2024-12-20
+#### Added
+#### Changed
+#### Fixed
+* Fixed an issue with the helm chart when SASL and Connectors were enabled that caused a volume to be mounted incorrectly.
+#### Removed
+
 ### [5.9.17](https://github.com/redpanda-data/helm-charts/releases/tag/redpanda-5.9.17) - 2024-12-17
 #### Added
 #### Changed

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,11 +23,11 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.9.17
+version: 5.9.18
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging
-appVersion: v24.3.1
+appVersion: v24.3.2
 
 # kubeVersion must be suffixed with "-0" to be able to match cloud providers
 # kubernetes versions like "v1.23.8-gke.1900". Their suffix is interpreted as a

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Helm chart.
 ---
 
-![Version: 5.9.17](https://img.shields.io/badge/Version-5.9.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.3.1](https://img.shields.io/badge/AppVersion-v24.3.1-informational?style=flat-square)
+![Version: 5.9.18](https://img.shields.io/badge/Version-5.9.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.3.2](https://img.shields.io/badge/AppVersion-v24.3.2-informational?style=flat-square)
 
 This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/redpanda/testdata/template-cases.txtar
+++ b/charts/redpanda/testdata/template-cases.txtar
@@ -973,3 +973,154 @@ tolerations:
     value: redpanda
 tuning:
   tune_aio_events: false
+
+-- some-company-1 --
+# ASSERT-NO-ERROR
+# ASSERT-GOLDEN
+auth:
+  sasl:
+    enabled: true
+    mechanism: SCRAM-SHA-512
+    secretRef: kafka-credentials
+config:
+  cluster:
+    election_timeout_ms: 5000
+    enable_leader_balancer: true
+    partition_autobalancing_mode: continuous
+    raft_heartbeat_interval_ms: 500
+connectors:
+  deployment:
+    extraEnv:
+    - name: CONNECT_PLUGIN_PATH
+      value: /opt/kafka/connect-plugins
+    podAntiAffinity:
+      custom:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: redpanda-statefulset
+              app.kubernetes.io/instance: redpanda
+              app.kubernetes.io/name: redpanda
+          topologyKey: kubernetes.io/hostname
+    strategy:
+      type: Recreate
+  enabled: true
+  monitoring:
+    enabled: true
+  storage:
+    volume:
+    - name: plugins
+      persistentVolumeClaim:
+        claimName: plugins-redpanda-connectors-redpanda
+    volumeMounts:
+    - mountPath: /opt/kafka/connect-plugins
+      name: plugins
+      readOnly: false
+  test:
+    create: true
+console:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: redpanda-statefulset
+            app.kubernetes.io/instance: redpanda
+            app.kubernetes.io/name: redpanda
+        topologyKey: kubernetes.io/hostname
+  console:
+    config:
+      connect:
+        connectTimeout: 15s
+        readTimeout: 60s
+        requestTimeout: 6s
+  ingress:
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-production
+      nginx.ingress.kubernetes.io/auth-realm: '"Authentication required"'
+      nginx.ingress.kubernetes.io/auth-secret: ingress-basic-auth-credentials
+      nginx.ingress.kubernetes.io/auth-type: basic
+    className: nginx
+    enabled: true
+    hosts:
+    - host: console.redpanda.dev.somecustomer.net
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+    tls:
+    - hosts:
+      - console.redpanda.dev.somecustomer.net
+      secretName: redpanda-console-production-tls
+  tests:
+    enabled: true
+enterprise:
+  licenseSecretRef:
+    key: license
+    name: redpanda-enterprise-license
+external:
+  domain: redpanda.dev.somecustomer.net
+  enabled: true
+  externalDns:
+    enabled: true
+  type: LoadBalancer
+listeners:
+  admin:
+    external:
+      default:
+        enabled: false
+  http:
+    external:
+      default:
+        enabled: false
+  kafka:
+    external:
+      default:
+        enabled: true
+  rpc:
+    tls:
+      enabled: false
+  schemaRegistry:
+    external:
+      default:
+        enabled: false
+monitoring:
+  enabled: true
+resources:
+  cpu:
+    cores: "7"
+  memory:
+    container:
+      max: 25Gi
+      min: 20Gi
+    enable_memory_locking: true
+statefulset:
+  initContainers:
+    configurator:
+      resources:
+        limits:
+          cpu: "1"
+          memory: 1Gi
+    setDataDirOwnership:
+      enabled: true
+    tuning:
+      resources:
+        limits:
+          cpu: "1"
+          memory: 1Gi
+  replicas: 3
+storage:
+  hostPath: /redpanda-data
+  persistentVolume:
+    enabled: true
+    size: 500Gi
+    storageClass: ""
+tests:
+  enabled: true
+tls:
+  certs:
+    external:
+      caEnabled: false
+      issuerRef:
+        kind: ClusterIssuer
+        name: letsencrypt-production
+  enabled: true


### PR DESCRIPTION
This is a release with the bugfix for connectors + SASL enabled. It also adds a redacted customer golden file test. Currently the tests with subchart renderers render out the helm `test` files (found in a subchart's `test` directory), which frankly render improperly, but the actual deployment resource that gets rendered now look fine to me.