### PR TITLE
Remove testdata autogeneration as go files are in redpanda-operator repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,13 +75,6 @@ jobs:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: true
           CR_GENERATE_RELEASE_NOTES: true
-      - name: Update testdata
-        run: go test ./charts/redpanda -update -short
-      - name: Commit changes for testdata golden files
-        run: |
-          git add charts/redpanda/testdata
-          git commit -m "[Auto Commit] Update testdata golden files"
-          git push
       - name: Checkout kustomize
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Release pipeline failed as go files are removed from helm-charts repo.

Reference

https://github.com/redpanda-data/helm-charts/pull/1640

https://github.com/redpanda-data/helm-charts/pull/1163

https://github.com/redpanda-data/helm-charts/actions/runs/13522159670/job/37783691343#step:11:17

P.S. This autogeneration was created to over come issue with bumping dependency version of Redpanda chart.