### PR TITLE
ci: use cert-manager LTS 1.12.16

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -133,7 +133,7 @@ jobs:
         run: |
           helm repo add jetstack https://charts.jetstack.io &&
           helm install cert-manager --namespace cert-manager \
-            --create-namespace --version v1.11.0 jetstack/cert-manager \
+            --create-namespace --version v1.12.16 jetstack/cert-manager \
             --set installCRDs=true --wait --wait-for-jobs
       - name: Install prometheus-operator
         run: |

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -125,7 +125,7 @@ tasks:
         --create-namespace \
         --namespace cert-manager \
         --set installCRDs=true \
-        --version v1.11.0 \
+        --version v1.12.16 \
         --wait \
         --wait-for-jobs
 


### PR DESCRIPTION
The `cert-manager` version `1.11.0` used in tests and CI s quite dated and not more supported. Use the latest LTS version available `1.12.6` instead.

![image](https://github.com/user-attachments/assets/c604b09d-0c9c-4af4-a5fe-f9739d9531e5)


Refs:
- https://cert-manager.io/docs/releases/
- https://cert-manager.io/docs/releases/release-notes/release-notes-1.12/

