### PR TITLE
Feat/connect resources

### DIFF
--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -508,6 +508,28 @@ HTTP Scheme to use for scraping.
 
 **Default:** `"http"`
 
+### [connectResources](https://artifacthub.io/packages/helm/redpanda-data/connect?modal=values&path=connectResources)
+
+Configuration settings for the resources feature in Redpanda Connect.
+
+**Default:**
+
+```
+{"enabled":false,"resourcesConfigMap":""}
+```
+
+### [connectResources.enabled](https://artifacthub.io/packages/helm/redpanda-data/connect?modal=values&path=connectResources.enabled)
+
+Enable resources.
+
+**Default:** `false`
+
+### [resources.resourcesConfigMap](https://artifacthub.io/packages/helm/redpanda-data/connect?modal=values&path=connectResources.resourcesConfigMap)
+
+Name of the ConfigMap that contains resources configuration files.
+
+**Default:** `""`
+
 ### [streams](https://artifacthub.io/packages/helm/redpanda-data/connect?modal=values&path=streams)
 
 Configuration settings for the streams mode feature in Redpanda Connect.

--- a/charts/connect/templates/deployment.yaml
+++ b/charts/connect/templates/deployment.yaml
@@ -68,6 +68,10 @@ spec:
             {{- if eq .Values.telemetry false}}
             - --disable-telemetry
             {{- end }}
+            {{- if and .Values.connectResources.enabled .Values.connectResources.resourcesConfigMap }}
+            - "--resources"
+            - /resources/*.yaml
+            {{- end }}
             {{- if and .Values.streams.enabled .Values.streams.streamsConfigMap }}
             - "streams"
             {{- if eq .Values.streams.api.enable false }}
@@ -108,6 +112,11 @@ spec:
             {{- if .Values.extraVolumeMounts }}
               {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
+            {{- if and .Values.connectResources.enabled .Values.connectResources.resourcesConfigMap }}
+            - name: resources
+              mountPath: "/resources"
+              readOnly: true
+            {{- end }}
             {{- if and .Values.streams.enabled .Values.streams.streamsConfigMap }}
             - name: streams
               mountPath: "/streams"
@@ -135,6 +144,11 @@ spec:
             name: {{ template "redpanda-connect.fullname" . }}-config
         {{- if .Values.extraVolumes }}
           {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- end }}
+        {{- if and .Values.connectResources.enabled .Values.connectResources.resourcesConfigMap }}
+        - name: resources
+          configMap:
+            name: {{ .Values.connectResources.resourcesConfigMap }}
         {{- end }}
         {{- if and .Values.streams.enabled .Values.streams.streamsConfigMap }}
         - name: streams

--- a/charts/connect/tests/deployment_test.yaml
+++ b/charts/connect/tests/deployment_test.yaml
@@ -132,6 +132,41 @@ tests:
                 - name: My-Header
                   value: Foo
 
+  - it: should enable resources
+    set:
+      deployment:
+        rolloutConfigMap: false
+      connectResources:
+        enabled: true
+        resourcesConfigMap: "my-config-map"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - -c
+            - /redpanda-connect.yaml
+            - --resources
+            - /resources/*.yaml
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - mountPath: /redpanda-connect.yaml
+              name: config
+              readOnly: true
+              subPath: redpanda-connect.yaml
+            - mountPath: /resources
+              name: resources
+              readOnly: true
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - configMap:
+                name: RELEASE-NAME-redpanda-connect-config
+              name: config
+            - configMap:
+                name: my-config-map
+              name: resources
+
   - it: should enable streams
     set:
       deployment:

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -253,6 +253,13 @@ extraVolumeMounts:
   # - name: secret
   #   mountPath: /mnt/secret
   #   readOnly: true
+# 
+# -- Configuration settings for resources in Redpanda Connect.
+connectResources:
+  # -- Enable resources.
+  enabled: false
+  # -- Name of the ConfigMap that contains resources configuration files.
+  resourcesConfigMap: ""
 
 # -- Configuration settings for the streams mode feature in Redpanda Connect.
 streams:


### PR DESCRIPTION
### Pull Request: Adjustments to the helm chart for Redpanda Connect [to allow resources](https://docs.redpanda.com/redpanda-connect/configuration/resources/#with-imports).

#### Summary
In this PR, changes were made to the Helm Chart for the Redpanda Connect product to implement support for shared Connect resources. These changes allow for improved resource utilization and configuration flexibility.

#### Changes in detail
- **Documentation updated**: The documentation has been adapted according to the new functions to explain the use of shared resources.
- **HELM tests created**: A new test has been implemented to check the functionality of the changes and ensure that everything works as expected.
- **values.yaml extended**: Updated the `values.yaml` file to add new configuration options for resource usage.
- **deployment.yaml customized**: The `deployment.yaml` file has been extended to ensure that the CLI flags are passed correctly and the resources are read in via a ConfigMap and mounted to a volume.

#### Motivation
These changes aim to improve the efficiency and user-friendliness of Redpanda Connect by enabling flexible resource usage. The adjustments are a step towards better scalability and management of Connect running in e.g. `streams` mode.

#### Next steps
Please review the changes and provide your feedback. 
I look forward to your feedback!
