### PR TITLE
console: update version to `v3.0.0`

### DIFF
--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -27,7 +27,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Chart versions do not track appVersion
-version: 3.0-k8s0
+version: 3.0.0
 
 # The app version is the version of the Chart application
 appVersion: v3.0.0

--- a/charts/console/README.md
+++ b/charts/console/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Console Helm chart.
 ---
 
-![Version: 3.0-k8s0](https://img.shields.io/badge/Version-3.0--k8s0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.0.0](https://img.shields.io/badge/AppVersion-v3.0.0-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.0.0](https://img.shields.io/badge/AppVersion-v3.0.0-informational?style=flat-square)
 
 This page describes the official Redpanda Console Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/console/values.yaml).
 Each of the settings is listed and described on this page, along with any default values.


### PR DESCRIPTION
Our attempts to differentiate between chart versions and their appVersions have been thwarted by semver considering any version with a `-` a prerelease version.

This commit manually moves console's version to v3.0.0 so it shows up as the latest console chart version.

A follow up commit will perform the change in the operator monorepo.