### PR TITLE
Remove none existent configurator tag

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2368,8 +2368,6 @@ entries:
       artifacthub.io/images: |
         - name: redpanda-operator
           image: docker.redpanda.com/redpandadata/redpanda-operator:v2.3.7-24.3.6
-        - name: configurator
-          image: docker.redpanda.com/redpandadata/configurator:v2.3.7-24.3.6
         - name: redpanda
           image: docker.redpanda.com/redpandadata/redpanda:v24.3.6
         - name: kube-rbac-proxy
@@ -2414,8 +2412,6 @@ entries:
       artifacthub.io/images: |
         - name: redpanda-operator
           image: docker.redpanda.com/redpandadata/redpanda-operator:v2.3.6-24.3.3
-        - name: configurator
-          image: docker.redpanda.com/redpandadata/configurator:v2.3.6-24.3.3
         - name: redpanda
           image: docker.redpanda.com/redpandadata/redpanda:v24.3.3
         - name: kube-rbac-proxy


### PR DESCRIPTION
Artifact Hub is scanning our index.yaml and could not perform security vulnerabilities as configurator tag was not created.

```
error scanning image docker.redpanda.com/redpandadata/configurator:v2.3.7-24.3.6: image not found (package operator:0.4.40)
```

Reference
Last configurator image pushed to configurator docker hub https://hub.docker.com/layers/redpandadata/configurator/v2.3.5-24.3.2/images/sha256-9c0035879910e865109ad68afca9d34c1c5724b0bb0ace34de1c7862aa1c46c4

https://artifacthub.io/control-panel/repositories?modal=scanning&user-alias=&org-name=redpanda&repo-name=redpanda-data

https://github.com/redpanda-data/redpanda-operator/pull/524