### PR TITLE
Remove wrong image annotation

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -5259,7 +5259,6 @@ entries:
           image: docker.redpanda.com/redpandadata/redpanda-operator:v23.2.1
         - name: redpanda
           image: docker.redpanda.com/redpandadata/redpanda:v23.2.1
-        - name: gco.io/kubebuilder/kube-rbac-proxy:v0.8.0
       artifacthub.io/license: Apache-2.0
       artifacthub.io/links: |
         - name: Documentation


### PR DESCRIPTION
The artifacthub.io reported following problem in operator helm metadata:
```
error preparing package: error enriching package from annotations: 1 error occurred:
	* invalid annotation: 1 error occurred:
	* invalid image reference: could not parse reference:

 (package: operator version: 0.3.2)
```

The name was set as image reference and the image was missing. As kube-rbac proxy is not longer supported it is now removed from old operator version annotation.