### PR TITLE
kminion: bump app version to 2.2.13. Release 0.14.2

### DIFF
--- a/charts/kminion/Chart.yaml
+++ b/charts/kminion/Chart.yaml
@@ -25,11 +25,11 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.14.1
+version: 0.14.2
 
 # The app version is the default version of Kminion to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging
-appVersion: v2.2.8
+appVersion: v2.2.13
 
 icon: https://images.ctfassets.net/paqvtpyf8rwu/3cYHw5UzhXCbKuR24GDFGO/73fb682e6157d11c10d5b2b5da1d5af0/skate-stand-panda.svg
 sources:
@@ -43,4 +43,4 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: kminion
-      image: docker.redpanda.com/redpandadata/kminion:v2.2.5
+      image: docker.redpanda.com/redpandadata/kminion:v2.2.13

--- a/charts/kminion/README.md
+++ b/charts/kminion/README.md
@@ -6,7 +6,7 @@ tags:
 description: The most popular Open Source Kafka JMX to Prometheus tool by the creators of [Redpanda Console](https://github.com/redpanda-data/console) and Redpanda
 ---
 
-![Version: 0.14.1](https://img.shields.io/badge/Version-0.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.2.8](https://img.shields.io/badge/AppVersion-v2.2.8-informational?style=flat-square)
+![Version: 0.14.2](https://img.shields.io/badge/Version-0.14.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.2.13](https://img.shields.io/badge/AppVersion-v2.2.13-informational?style=flat-square)
 
 This page describes the official Redpanda KMinion Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/kminion/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 


### PR DESCRIPTION
Bump default `kminion` chart appVersion to `2.2.13` to bring in all the latest security fixes and update the chart version to `0.14.2`.


Refs:
- https://github.com/redpanda-data/kminion/compare/v2.2.8...v2.2.13