### PR TITLE
charts/console: Remove unrecognized flags from wget

### DIFF
--- a/charts/console/templates/tests/test-connection.yaml
+++ b/charts/console/templates/tests/test-connection.yaml
@@ -16,7 +16,7 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "console.fullname" . }}:{{ .Values.service.port }}', '--retry-connrefused', '--waitretry=1', '--read-timeout=20', '--timeout=15', '-t 20']
+      args: ['{{ include "console.fullname" . }}:{{ .Values.service.port }}', '--timeout=15', '-t 20']
   restartPolicy: Never
   priorityClassName: {{ .Values.priorityClassName | quote }}
 {{- end }}


### PR DESCRIPTION
I found that wget inside busybox is not the same as the one that I read the man page. I was surprised that test in PR that cut console helm chart v3.1.0 #1684 did not complain about `unrecognized flags`. The proof that the fix works is the successful  pipeline execution in #1683. I deliberately replaced in the Github Release [v3.1.0](https://github.com/redpanda-data/helm-charts/releases/tag/console-3.1.0) the artifact `console-v3.1.0.tgz`, because it is the place of reference from our [index.yaml file](https://github.com/redpanda-data/helm-charts/commit/c71fcf9aed034805c251546055981daf6bc64aaf#diff-08c65c1b5ef8384ef0200558777c52f4110afcbbacc880ac5375d555ca97ee3eR570-R571).