### PR TITLE
feat(kminion): add servicemonitor.metricRelabelings

### DIFF
--- a/charts/kminion/README.md
+++ b/charts/kminion/README.md
@@ -241,6 +241,10 @@ The port for kminion metrics endpoint
 
 **Default:** `"15s"`
 
+### [serviceMonitor.metricRelabelings](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=serviceMonitor.metricRelabelings)
+
+**Default:** `[]`
+
 ### [serviceMonitor.relabelings](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=serviceMonitor.relabelings)
 
 **Default:** `[]`

--- a/charts/kminion/templates/servicemonitor.yaml
+++ b/charts/kminion/templates/servicemonitor.yaml
@@ -39,6 +39,10 @@ spec:
       relabelings:
       {{ toYaml .Values.serviceMonitor.relabelings | nindent 6 }}
       {{- end }}
+      {{- if .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+      {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
+      {{- end }}
   {{- if .Values.serviceMonitor.targetLabels}}
   targetLabels:
     {{- toYaml .Values.serviceMonitor.targetLabels | nindent 4}}

--- a/charts/kminion/values.yaml
+++ b/charts/kminion/values.yaml
@@ -160,6 +160,7 @@ serviceMonitor:
   #   targetLabel: my_label
   #   replacement: $1
   #   action: replace
+  metricRelabelings: []
 
 # For DaemonSet mode you may set daemonset to "true" and replicaCount to 0.
 daemonset:


### PR DESCRIPTION
I would like to suggest to be able to specify `metricRelabelings` in the servicemonitor.