### PR TITLE
Fix kminion helm chart test workflows

### DIFF
--- a/.github/ct-kminion.yaml
+++ b/.github/ct-kminion.yaml
@@ -15,7 +15,7 @@
 debug: true
 remote: origin
 target-branch: main
-helm-extra-args: --timeout 900s
+helm-extra-args: --timeout 120s
 chart-repos:
   - redpanda=https://charts.redpanda.com
 charts:

--- a/.github/workflows/test_kminion.yaml
+++ b/.github/workflows/test_kminion.yaml
@@ -25,6 +25,8 @@ defaults:
 jobs:
   test:
     name: Run ct tests for kminion chart
+    env:
+      KMINION_NAMESPACE: kminion-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: true
     runs-on: ubuntu-22.04
@@ -58,13 +60,15 @@ jobs:
         run: |
           helm repo add redpanda https://charts.redpanda.com
           helm install --namespace redpanda --create-namespace redpanda redpanda/redpanda --wait --wait-for-jobs
-      - name: Copy Redpanda tls cert to kminion chart
+      - name: Copy Redpanda TLS cert to kminion namespace
         run: |
+          kubectl create namespace ${{ env.KMINION_NAMESPACE }} || true
           kubectl -n redpanda wait --for=condition=Ready --timeout=10m certificates/redpanda-default-cert
-          kubectl -n redpanda get secret -o yaml redpanda-default-cert | \
+          kubectl -n redpanda get secret redpanda-default-cert -o yaml | \
             sed -e '/namespace/d' | \
             sed -e '/resourceVersion/d' | \
-            sed -e '/uid/d'  > charts/kminion/templates/redpanda-tls.yaml
+            sed -e '/uid/d' | \
+            kubectl apply -n ${{ env.KMINION_NAMESPACE }} -f -
         # Chart-testing requires there to be a branch on the local repository
         # for diffing. This will create such a branch without performing a
         # checkout.
@@ -77,4 +81,5 @@ jobs:
             --upgrade \
             --config .github/ct-kminion.yaml \
             --skip-missing-values \
-            --target-branch ${{ github.event.repository.default_branch }}
+            --target-branch ${{ github.event.repository.default_branch }} \
+            --namespace ${{ env.KMINION_NAMESPACE }}


### PR DESCRIPTION
`kminion` helm-chart release tests `test-charts-kminion` is currently broken as the redpanda self-signed TLS cert is not properly copied into the target `kminion` K8s namespace as [can be seen in the test output](https://github.com/redpanda-data/helm-charts/actions/runs/17233073586/job/48891505716?pr=1679):
```
Testing upgrades of chart "kminion => (version: \"0.14.2\", path: \"charts/kminion\")" relative to previous revision "kminion => (version: \"0.14.1\", path: \"ct_previous_revision1507686549/charts/kminion\")"...

Installing chart "kminion => (version: \"0.14.1\", path: \"ct_previous_revision1507686549/charts/kminion\")" with values file "ct_previous_revision1507686549/charts/kminion/ci/01-default-values.yaml"...

Creating namespace "kminion-zh4xdl6ush"...
>>> kubectl --request-timeout=30s create namespace kminion-zh4xdl6ush
namespace/kminion-zh4xdl6ush created
>>> helm install kminion-zh4xdl6ush ct_previous_revision1507686549/charts/kminion --namespace kminion-zh4xdl6ush --wait --values ct_previous_revision1507686549/charts/kminion/ci/01-default-values.yaml --timeout 900s
Error: INSTALLATION FAILED: context deadline exceeded
```

[and](https://github.com/redpanda-data/helm-charts/actions/runs/17233073586/job/48891505716?pr=1679#step:12:49) : 
```
  40s         Warning   FailedMount         pod/kminion-zh4xdl6ush-85787dc7-cjxpz                kubelet, chart-testing-worker4   MountVolume.SetUp failed for volume "redpanda-default-cert" : secret "redpanda-default-cert" not found   15m          15      kminion-zh4xdl6ush-85787dc7-cjxpz.185f4541fd0745d7
```

The missing secret prevents the `kminion` pod from starting. The reason is the redpanda self-signed TLS cert `redpanda-default-cert` is not properly copied into the kminion test K8s namespace (as the install is executed from a new git worktree that does not copy untracked files (incl. the cert) on creation) causing the `helm install` test to fail.

This PR fixes the problem by creating the K8s namespace and copying the `redpanda-default-cert` Secret into the namespace prior to executing the chart-testing test suite. Additionally, helm install/upgrade timeout is cut from 900s to 120s for a faster feedback loop.

