### PR TITLE
Add namespaceOverride to connect chart

### DIFF
--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -392,6 +392,12 @@ Additional init containers to add to the Deployment.
 
 **Default:** `""`
 
+### [namespaceOverride](https://artifacthub.io/packages/helm/redpanda-data/connect?modal=values&path=namespaceOverride)
+
+Namespace to deploy Redpanda Connect into. By default, uses the namespace of the Helm release.
+
+**Default:** `""`
+
 ### [nodeSelector](https://artifacthub.io/packages/helm/redpanda-data/connect?modal=values&path=nodeSelector)
 
 Node selector for scheduling Pods.

--- a/charts/connect/templates/_helpers.tpl
+++ b/charts/connect/templates/_helpers.tpl
@@ -6,6 +6,13 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Expand the namespace the chart is deployed into.
+*/}}
+{{- define "redpanda-connect.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride }}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/charts/connect/templates/configmap.yaml
+++ b/charts/connect/templates/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "redpanda-connect.fullname" . }}-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "redpanda-connect.namespace" . }}
   labels:
     {{- include "redpanda-connect.labels" . | nindent 4 }}
 data:

--- a/charts/connect/templates/deployment.yaml
+++ b/charts/connect/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "redpanda-connect.fullname" . }}
+  namespace: {{ include "redpanda-connect.namespace" . }}
   labels:
     {{- include "redpanda-connect.labels" . | nindent 4 }}
   annotations:

--- a/charts/connect/templates/hpa.yaml
+++ b/charts/connect/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "redpanda-connect.fullname" . }}
+  namespace: {{ include "redpanda-connect.namespace" . }}
   labels:
     {{- include "redpanda-connect.labels" . | nindent 4 }}
 spec:

--- a/charts/connect/templates/ingress.yaml
+++ b/charts/connect/templates/ingress.yaml
@@ -16,6 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "redpanda-connect.namespace" . }}
   labels:
     {{- include "redpanda-connect.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/connect/templates/pdb.yaml
+++ b/charts/connect/templates/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "redpanda-connect.fullname" . }}
+  namespace: {{ include "redpanda-connect.namespace" . }}
   labels:
     {{- include "redpanda-connect.labels" . | nindent 4 }}
 spec:

--- a/charts/connect/templates/service.yaml
+++ b/charts/connect/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "redpanda-connect.fullname" . }}
+  namespace: {{ include "redpanda-connect.namespace" . }}
   labels:
     {{- include "redpanda-connect.labels" . | nindent 4 }}
   annotations:

--- a/charts/connect/templates/serviceaccount.yaml
+++ b/charts/connect/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "redpanda-connect.serviceAccountName" . }}
+  namespace: {{ include "redpanda-connect.namespace" . }}
   labels:
     {{- include "redpanda-connect.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/connect/templates/servicemonitor.yaml
+++ b/charts/connect/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "redpanda-connect.fullname" . }}
+  namespace: {{ include "redpanda-connect.namespace" . }}
   labels:
     {{- include "redpanda-connect.labels" . | nindent 4 }}
 spec:

--- a/charts/connect/templates/tests/test-connection.yaml
+++ b/charts/connect/templates/tests/test-connection.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "redpanda-connect.fullname" . }}-test-connection"
+  namespace: {{ include "redpanda-connect.namespace" . }}
   labels:
     {{- include "redpanda-connect.labels" . | nindent 4 }}
   annotations:

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -79,6 +79,9 @@ nameOverride: ""
 # -- Override for the full name template.
 fullnameOverride: ""
 
+# -- Namespace to deploy Redpanda Connect into. By default, uses the namespace of the Helm release.
+namespaceOverride: ""
+
 # -- Configuration for the Kubernetes ServiceAccount associated with the Redpanda Connect Pods.
 serviceAccount:
   # -- Specify whether a ServiceAccount should be created.


### PR DESCRIPTION
Added the `namespaceOverride` option to the connect chart, allowing deployment to a specified namespace.