### PR TITLE
ci/task: upgrade cert-manager to 1.19.4

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -123,7 +123,7 @@ tasks:
         --create-namespace \
         --namespace cert-manager \
         --set installCRDs=true \
-        --version v1.12.16 \
+        --version v1.19.4 \
         --wait \
         --wait-for-jobs
 


### PR DESCRIPTION
The PR upgrades `cert-manager` used in various CI tasks to the latest supported `v1.19` version `1.19.4` as `v1.12` is now EOL.

Refs:
* https://cert-manager.io/docs/releases/release-notes/release-notes-1.19/
* https://cert-manager.io/docs/releases/#currently-supported-releases