### PR TITLE
kminion: bump chart version to 0.15.1

### DIFF
--- a/charts/kminion/Chart.yaml
+++ b/charts/kminion/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.15.0
+version: 0.15.1
 
 # The app version is the default version of Kminion to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/kminion/README.md
+++ b/charts/kminion/README.md
@@ -6,7 +6,7 @@ tags:
 description: The most popular Open Source Kafka JMX to Prometheus tool by the creators of [Redpanda Console](https://github.com/redpanda-data/console) and Redpanda
 ---
 
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.3.0](https://img.shields.io/badge/AppVersion-v2.3.0-informational?style=flat-square)
+![Version: 0.15.1](https://img.shields.io/badge/Version-0.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.3.0](https://img.shields.io/badge/AppVersion-v2.3.0-informational?style=flat-square)
 
 This page describes the official Redpanda KMinion Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/kminion/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 


### PR DESCRIPTION
Bumped to 0.15.1 because chart-releaser recognized 0.15.0 as a version that already exists, and 0.15.0 thus still relies on kminion v2.3.0-rc2.

Follow-up on #1728 