### PR TITLE
connect: add commonAnnotations support and bump to 4.86.0

### DIFF
--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -24,11 +24,11 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 3.1.0
+version: 3.2.0
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging
-appVersion: "4.68.0"
+appVersion: "4.86.0"
 
 sources:
   - https://github.com/redpanda-data/helm-charts
@@ -41,6 +41,6 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda
-      image: docker.redpanda.com/redpandadata/connect:4.42.0
+      image: docker.redpanda.com/redpandadata/connect:4.86.0
     - name: busybox
       image: busybox:latest

--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Connect Helm chart.
 ---
 
-![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.68.0](https://img.shields.io/badge/AppVersion-4.68.0-informational?style=flat-square)
+![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.86.0](https://img.shields.io/badge/AppVersion-4.86.0-informational?style=flat-square)
 
 Redpanda Connect is a high performance and resilient stream processor, able to connect various sources and sinks in a range of brokering patterns and perform hydration, enrichments, transformations and filters on payloads.
 

--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -80,6 +80,12 @@ Override the default entrypoint command of the container.
 
 **Default:** `[]`
 
+### [commonAnnotations](https://artifacthub.io/packages/helm/redpanda-data/connect?modal=values&path=commonAnnotations)
+
+Additional annotations to apply to all resources created by this chart.
+
+**Default:** `{}`
+
 ### [commonLabels](https://artifacthub.io/packages/helm/redpanda-data/connect?modal=values&path=commonLabels)
 
 Additional labels to apply to all resources created by this chart.

--- a/charts/connect/templates/_helpers.tpl
+++ b/charts/connect/templates/_helpers.tpl
@@ -53,6 +53,15 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+Common annotations
+*/}}
+{{- define "redpanda-connect.commonAnnotations" -}}
+{{- if .Values.commonAnnotations }}
+{{- tpl (toYaml .Values.commonAnnotations) . }}
+{{- end }}
+{{- end }}
+
+{{/*
 Selector labels
 */}}
 {{- define "redpanda-connect.selectorLabels" -}}

--- a/charts/connect/templates/configmap.yaml
+++ b/charts/connect/templates/configmap.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ include "redpanda-connect.namespace" . }}
   labels:
     {{- include "redpanda-connect.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
 data:
   redpanda-connect.yaml: |
     {{- with .Values.logger }}

--- a/charts/connect/templates/deployment.yaml
+++ b/charts/connect/templates/deployment.yaml
@@ -5,8 +5,13 @@ metadata:
   namespace: {{ include "redpanda-connect.namespace" . }}
   labels:
     {{- include "redpanda-connect.labels" . | nindent 4 }}
+  {{- if or .Values.commonAnnotations .Values.deployment.annotations }}
   annotations:
-    {{- toYaml .Values.deployment.annotations | nindent 4 }}
+    {{- include "redpanda-connect.commonAnnotations" . | nindent 4 }}
+    {{- with .Values.deployment.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.deployment.replicaCount }}
@@ -24,6 +29,9 @@ spec:
         {{- if .Values.deployment.rolloutConfigMap }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end}}
+      {{- with .Values.commonAnnotations }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       {{- with .Values.deployment.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/connect/templates/hpa.yaml
+++ b/charts/connect/templates/hpa.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ include "redpanda-connect.namespace" . }}
   labels:
     {{- include "redpanda-connect.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/connect/templates/ingress.yaml
+++ b/charts/connect/templates/ingress.yaml
@@ -19,9 +19,12 @@ metadata:
   namespace: {{ include "redpanda-connect.namespace" . }}
   labels:
     {{- include "redpanda-connect.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- if or .Values.commonAnnotations .Values.ingress.annotations }}
   annotations:
+    {{- include "redpanda-connect.commonAnnotations" . | nindent 4 }}
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/charts/connect/templates/pdb.yaml
+++ b/charts/connect/templates/pdb.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ include "redpanda-connect.namespace" . }}
   labels:
     {{- include "redpanda-connect.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
 spec:
 {{- with .Values.podDisruptionBudget.minAvailable }}
   minAvailable: {{ . }}

--- a/charts/connect/templates/service.yaml
+++ b/charts/connect/templates/service.yaml
@@ -6,8 +6,13 @@ metadata:
   namespace: {{ include "redpanda-connect.namespace" . }}
   labels:
     {{- include "redpanda-connect.labels" . | nindent 4 }}
+  {{- if or .Values.commonAnnotations .Values.service.annotations }}
   annotations:
-    {{- toYaml .Values.service.annotations | nindent 4 }}
+    {{- include "redpanda-connect.commonAnnotations" . | nindent 4 }}
+    {{- with .Values.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/connect/templates/serviceaccount.yaml
+++ b/charts/connect/templates/serviceaccount.yaml
@@ -6,8 +6,11 @@ metadata:
   namespace: {{ include "redpanda-connect.namespace" . }}
   labels:
     {{- include "redpanda-connect.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- if or .Values.commonAnnotations .Values.serviceAccount.annotations }}
   annotations:
+    {{- include "redpanda-connect.commonAnnotations" . | nindent 4 }}
+    {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/connect/templates/servicemonitor.yaml
+++ b/charts/connect/templates/servicemonitor.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ include "redpanda-connect.namespace" . }}
   labels:
     {{- include "redpanda-connect.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
 spec:
   endpoints:
     - interval: {{ .Values.serviceMonitor.interval}}

--- a/charts/connect/tests/configuration_test.yaml
+++ b/charts/connect/tests/configuration_test.yaml
@@ -96,6 +96,23 @@ tests:
       - matchSnapshot:
           path: data
 
+  - it: should apply commonAnnotations to configmap
+    set:
+      commonAnnotations:
+        example.com/team: platform
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            example.com/team: platform
+
+  - it: should not have configmap annotations when commonAnnotations empty
+    set:
+      commonAnnotations: {}
+    asserts:
+      - isNull:
+          path: metadata.annotations
+
   - it: should set config from string
     set:
       config: |

--- a/charts/connect/tests/deployment_test.yaml
+++ b/charts/connect/tests/deployment_test.yaml
@@ -338,6 +338,72 @@ tests:
             - mountPath: /custom-config
               name: templated-volume
 
+  - it: should apply commonAnnotations to deployment metadata
+    set:
+      deployment:
+        rolloutConfigMap: false
+      commonAnnotations:
+        example.com/team: platform
+        example.com/env: prod
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            example.com/env: prod
+            example.com/team: platform
+
+  - it: should apply commonAnnotations to pod template
+    set:
+      deployment:
+        rolloutConfigMap: false
+      commonAnnotations:
+        example.com/team: platform
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            example.com/team: platform
+
+  - it: should merge commonAnnotations with deployment annotations
+    set:
+      deployment:
+        rolloutConfigMap: false
+        annotations:
+          deploy-key: deploy-value
+      commonAnnotations:
+        example.com/team: platform
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            deploy-key: deploy-value
+            example.com/team: platform
+
+  - it: should merge commonAnnotations with pod annotations
+    set:
+      deployment:
+        rolloutConfigMap: false
+        podAnnotations:
+          pod-key: pod-value
+      commonAnnotations:
+        example.com/team: platform
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            example.com/team: platform
+            pod-key: pod-value
+
+  - it: should not have deployment annotations when all empty
+    set:
+      deployment:
+        rolloutConfigMap: false
+        annotations: {}
+      commonAnnotations: {}
+    asserts:
+      - isNull:
+          path: metadata.annotations
+
   - it: should support multiple template expressions in extraVolumes and extraVolumeMounts
     set:
       deployment:

--- a/charts/connect/tests/hpa_test.yaml
+++ b/charts/connect/tests/hpa_test.yaml
@@ -10,6 +10,27 @@ tests:
       - matchSnapshot:
           path: spec
 
+  - it: should apply commonAnnotations to hpa
+    set:
+      autoscaling:
+        enabled: true
+      commonAnnotations:
+        example.com/team: platform
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            example.com/team: platform
+
+  - it: should not have hpa annotations when commonAnnotations empty
+    set:
+      autoscaling:
+        enabled: true
+      commonAnnotations: {}
+    asserts:
+      - isNull:
+          path: metadata.annotations
+
   - it: should configure autoscaler custom
     set:
       autoscaling:

--- a/charts/connect/tests/ingress_test.yaml
+++ b/charts/connect/tests/ingress_test.yaml
@@ -19,3 +19,52 @@ tests:
     asserts:
       - matchSnapshot:
           path: spec
+
+  - it: should apply commonAnnotations to ingress
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: test.local
+            paths:
+              - path: /
+      commonAnnotations:
+        example.com/team: platform
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            example.com/team: platform
+
+  - it: should merge commonAnnotations with ingress annotations
+    set:
+      ingress:
+        enabled: true
+        annotations:
+          nginx.ingress.kubernetes.io/rewrite-target: /
+        hosts:
+          - host: test.local
+            paths:
+              - path: /
+      commonAnnotations:
+        example.com/team: platform
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            example.com/team: platform
+            nginx.ingress.kubernetes.io/rewrite-target: /
+
+  - it: should not have ingress annotations when all empty
+    set:
+      ingress:
+        enabled: true
+        annotations: {}
+        hosts:
+          - host: test.local
+            paths:
+              - path: /
+      commonAnnotations: {}
+    asserts:
+      - isNull:
+          path: metadata.annotations

--- a/charts/connect/tests/service_monitor_test.yaml
+++ b/charts/connect/tests/service_monitor_test.yaml
@@ -12,6 +12,27 @@ tests:
           path: spec.endpoints[0].scheme
           value: https
 
+  - it: should apply commonAnnotations to service monitor
+    set:
+      serviceMonitor:
+        enabled: true
+      commonAnnotations:
+        example.com/team: platform
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            example.com/team: platform
+
+  - it: should not have service monitor annotations when commonAnnotations empty
+    set:
+      serviceMonitor:
+        enabled: true
+      commonAnnotations: {}
+    asserts:
+      - isNull:
+          path: metadata.annotations
+
   - it: should set scheme default
     set:
       serviceMonitor:

--- a/charts/connect/tests/service_test.yaml
+++ b/charts/connect/tests/service_test.yaml
@@ -25,9 +25,8 @@ tests:
     values:
       - ../values.yaml
     asserts:
-      - equal:
+      - isNull:
           path: metadata.annotations
-          value: {}
 
   - it: should contain filled annotations
     templates:

--- a/charts/connect/tests/service_test.yaml
+++ b/charts/connect/tests/service_test.yaml
@@ -40,3 +40,38 @@ tests:
           path: metadata.annotations
           value:
             test: test
+
+  - it: should apply commonAnnotations only
+    set:
+      commonAnnotations:
+        example.com/team: platform
+        example.com/env: prod
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            example.com/env: prod
+            example.com/team: platform
+
+  - it: should merge commonAnnotations with service annotations
+    set:
+      commonAnnotations:
+        example.com/team: platform
+      service:
+        annotations:
+          svc-key: svc-value
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            example.com/team: platform
+            svc-key: svc-value
+
+  - it: should not have annotations when commonAnnotations removed
+    set:
+      commonAnnotations: {}
+      service:
+        annotations: {}
+    asserts:
+      - isNull:
+          path: metadata.annotations

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -61,6 +61,9 @@ deployment:
 # -- Additional labels to apply to all resources created by this chart.
 commonLabels: {}
 
+# -- Additional annotations to apply to all resources created by this chart.
+commonAnnotations: {}
+
 # -- Configuration for the Redpanda Connect container image.
 image:
   # -- Docker repository for the Redpanda Connect image.


### PR DESCRIPTION
## Summary
- Introduce a `commonAnnotations` field (similar to `commonLabels`) that automatically merges into all generated resources, removing the need to duplicate annotations across `deployment.annotations`, `deployment.podAnnotations`, `ingress.annotations`, `service.annotations`, etc.
- Resource-specific annotations take precedence over `commonAnnotations`
- Supports `tpl` rendering for template expressions in annotation values
- Bump appVersion from 4.68.0 to 4.86.0, chart version to 3.2.0, and image tag to 4.86.0 (incorporates #1731)

## Motivation
Platform teams using Gatekeeper or similar policy engines need the same metadata annotations on every resource. Without `commonAnnotations`, users must duplicate annotations across `deployment.annotations`, `deployment.podAnnotations`, `ingress.annotations`, and `service.annotations` — leading to drift and compliance failures.

### Example: OPA Gatekeeper `K8sRequiredAnnotations`

The [`K8sRequiredAnnotations`](https://open-policy-agent.github.io/gatekeeper-library/website/validation/requiredannotations/) constraint template requires resources to contain specified annotations with values matching provided regular expressions. A typical platform constraint might look like:

```yaml
apiVersion: constraints.gatekeeper.sh/v1beta1
kind: K8sRequiredAnnotations
metadata:
  name: all-must-have-certain-set-of-annotations
spec:
  match:
    kinds:
      - apiGroups: [""]
        kinds: ["Service"]
      - apiGroups: ["apps"]
        kinds: ["Deployment"]
      - apiGroups: ["networking.k8s.io"]
        kinds: ["Ingress"]
  parameters:
    message: "All resources must have `a8r.io/owner` and `a8r.io/runbook` annotations."
    annotations:
      - key: a8r.io/owner
        allowedRegex: ^([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}|[a-z]{1,39})$
      - key: a8r.io/runbook
        allowedRegex: ^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$
```

**Before `commonAnnotations`** — every resource annotation block must be set individually:

```yaml
# values.yaml (before)
deployment:
  annotations:
    a8r.io/owner: "dev-team-alfa@contoso.com"
    a8r.io/runbook: "https://confluence.contoso.com/dev-team-alfa/runbooks"
  podAnnotations:
    a8r.io/owner: "dev-team-alfa@contoso.com"
    a8r.io/runbook: "https://confluence.contoso.com/dev-team-alfa/runbooks"
service:
  annotations:
    a8r.io/owner: "dev-team-alfa@contoso.com"
    a8r.io/runbook: "https://confluence.contoso.com/dev-team-alfa/runbooks"
ingress:
  annotations:
    a8r.io/owner: "dev-team-alfa@contoso.com"
    a8r.io/runbook: "https://confluence.contoso.com/dev-team-alfa/runbooks"
```

**After `commonAnnotations`** — a single block satisfies the constraint across all resources:

```yaml
# values.yaml (after)
commonAnnotations:
  a8r.io/owner: "dev-team-alfa@contoso.com"
  a8r.io/runbook: "https://confluence.contoso.com/dev-team-alfa/runbooks"
```

This eliminates duplication and ensures that every resource rendered by the chart passes the Gatekeeper constraint without per-resource configuration.

## Changes

### `values.yaml`
- Added `commonAnnotations: {}` field alongside existing `commonLabels`

### `templates/_helpers.tpl`
- Added `redpanda-connect.commonAnnotations` named template with `tpl` support for template expressions

### Templates updated to merge `commonAnnotations`
| Template | How annotations are applied |
|---|---|
| `deployment.yaml` (metadata) | `commonAnnotations` + `deployment.annotations` |
| `deployment.yaml` (pod spec) | `commonAnnotations` + `deployment.podAnnotations` |
| `service.yaml` | `commonAnnotations` + `service.annotations` |
| `ingress.yaml` | `commonAnnotations` + `ingress.annotations` |
| `serviceaccount.yaml` | `commonAnnotations` + `serviceAccount.annotations` |
| `configmap.yaml` | `commonAnnotations` (no prior annotation support) |
| `hpa.yaml` | `commonAnnotations` (no prior annotation support) |
| `pdb.yaml` | `commonAnnotations` (no prior annotation support) |
| `servicemonitor.yaml` | `commonAnnotations` (no prior annotation support) |

### Version bumps (`Chart.yaml`, `README.md`)
- Chart version: 3.1.0 → 3.2.0
- appVersion: 4.68.0 → 4.86.0
- artifacthub image annotation: 4.42.0 → 4.86.0

## Tests added (17 new, 46 total)

| Test suite | Test | What it verifies |
|---|---|---|
| `service_test.yaml` | should apply commonAnnotations only | commonAnnotations appear on Service metadata |
| `service_test.yaml` | should merge commonAnnotations with service annotations | Both commonAnnotations and `service.annotations` are present |
| `service_test.yaml` | should not have annotations when commonAnnotations removed | No annotations block when both are empty |
| `deployment_test.yaml` | should apply commonAnnotations to deployment metadata | commonAnnotations appear on Deployment metadata |
| `deployment_test.yaml` | should apply commonAnnotations to pod template | commonAnnotations appear on Pod template metadata |
| `deployment_test.yaml` | should merge commonAnnotations with deployment annotations | Both commonAnnotations and `deployment.annotations` are present |
| `deployment_test.yaml` | should merge commonAnnotations with pod annotations | Both commonAnnotations and `deployment.podAnnotations` are present |
| `deployment_test.yaml` | should not have deployment annotations when all empty | No annotations block when both are empty |
| `ingress_test.yaml` | should apply commonAnnotations to ingress | commonAnnotations appear on Ingress metadata |
| `ingress_test.yaml` | should merge commonAnnotations with ingress annotations | Both commonAnnotations and `ingress.annotations` are present |
| `ingress_test.yaml` | should not have ingress annotations when all empty | No annotations block when both are empty |
| `configuration_test.yaml` | should apply commonAnnotations to configmap | commonAnnotations appear on ConfigMap metadata |
| `configuration_test.yaml` | should not have configmap annotations when commonAnnotations empty | No annotations block when empty |
| `hpa_test.yaml` | should apply commonAnnotations to hpa | commonAnnotations appear on HPA metadata |
| `hpa_test.yaml` | should not have hpa annotations when commonAnnotations empty | No annotations block when empty |
| `service_monitor_test.yaml` | should apply commonAnnotations to service monitor | commonAnnotations appear on ServiceMonitor metadata |
| `service_monitor_test.yaml` | should not have service monitor annotations when commonAnnotations empty | No annotations block when empty |

## Test plan
- [x] `helm template` with `commonAnnotations` set — verify annotations appear on all resources
- [x] `helm template` without `commonAnnotations` — verify no empty `annotations:` blocks are rendered
- [x] `helm template` with both `commonAnnotations` and resource-specific annotations — verify both appear and resource-specific takes precedence
- [x] `helm template` with `tpl` expressions in `commonAnnotations` — verify template rendering
- [x] `helm unittest` — 46 tests pass (17 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)