### PR TITLE
feat(kminion): add opt-in topologySpreadConstraints to deployment and daemonset

### DIFF
--- a/charts/kminion/Chart.yaml
+++ b/charts/kminion/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.15.1
+version: 0.15.2
 
 # The app version is the default version of Kminion to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/kminion/README.md
+++ b/charts/kminion/README.md
@@ -6,7 +6,7 @@ tags:
 description: The most popular Open Source Kafka JMX to Prometheus tool by the creators of [Redpanda Console](https://github.com/redpanda-data/console) and Redpanda
 ---
 
-![Version: 0.15.1](https://img.shields.io/badge/Version-0.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.3.0](https://img.shields.io/badge/AppVersion-v2.3.0-informational?style=flat-square)
+![Version: 0.15.2](https://img.shields.io/badge/Version-0.15.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.3.0](https://img.shields.io/badge/AppVersion-v2.3.0-informational?style=flat-square)
 
 This page describes the official Redpanda KMinion Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/kminion/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 
@@ -262,6 +262,10 @@ The port for kminion metrics endpoint
 **Default:** `true`
 
 ### [tolerations](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=tolerations)
+
+**Default:** `[]`
+
+### [topologySpreadConstraints](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=topologySpreadConstraints)
 
 **Default:** `[]`
 

--- a/charts/kminion/templates/daemonset.yaml
+++ b/charts/kminion/templates/daemonset.yaml
@@ -135,4 +135,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8}}
       {{- end}}
+      {{- with .Values.topologySpreadConstraints}}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8}}
+      {{- end}}
 {{- end }}

--- a/charts/kminion/templates/deployment.yaml
+++ b/charts/kminion/templates/deployment.yaml
@@ -140,3 +140,7 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8}}
       {{- end}}
+      {{- with .Values.topologySpreadConstraints}}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8}}
+      {{- end}}

--- a/charts/kminion/values.yaml
+++ b/charts/kminion/values.yaml
@@ -144,6 +144,9 @@ hostAliases: []
 
 affinity: {}
 
+# Spread Pods across your cluster. https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+topologySpreadConstraints: []
+
 customLabels: {}
 
 serviceMonitor:


### PR DESCRIPTION
Adds an opt-in `topologySpreadConstraints` field to the kminion chart's Deployment and DaemonSet, mirroring the existing knob in the sibling `connect` chart (`charts/connect`). It defaults to `[]`, so the rendered output is unchanged unless a user sets it.

This rounds out kminion's scheduling knobs (it already exposes `nodeSelector`, `affinity` and `tolerations`).

Validation (run locally):
- `ct lint --charts charts/kminion`: all charts linted successfully
- `actionlint`: clean
- `helm template` with default values: field is absent, render is byte-identical to before
- `helm template` with a constraint set: renders correctly on both the Deployment and the DaemonSet
- README regenerated with helm-docs v1.14.2

related: #1040