### PR TITLE
feat(kminion): add extraObjects

### DIFF
--- a/charts/kminion/README.md
+++ b/charts/kminion/README.md
@@ -97,6 +97,10 @@ Configure extra environment variables from Secrets and ConfigMaps.
 
 **Default:** `[]`
 
+### [extraObjects](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=extraObjects)
+
+**Default:** `[]`
+
 ### [fullnameOverride](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=fullnameOverride)
 
 **Default:** `""`
@@ -275,6 +279,3 @@ The port for kminion metrics endpoint
 
 **Default:** `[]`
 
-### [extraObjects](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=extraObjects)
-
-**Default:** `[]`

--- a/charts/kminion/README.md
+++ b/charts/kminion/README.md
@@ -275,3 +275,6 @@ The port for kminion metrics endpoint
 
 **Default:** `[]`
 
+### [extraObjects](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=extraObjects)
+
+**Default:** `[]`

--- a/charts/kminion/templates/extraobjects.yaml
+++ b/charts/kminion/templates/extraobjects.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (ternary . (toYaml .) (typeIs "string" .)) $ }}
+{{ end }}

--- a/charts/kminion/values.yaml
+++ b/charts/kminion/values.yaml
@@ -77,7 +77,6 @@ service:
     #   protocol: TCP
     #   name: expose-x509-for-ttl-checks
 
-
 ingress:
   enabled: false
   # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
@@ -359,3 +358,12 @@ tests:
   enabled: true
 
 configAutoReload: false
+
+# Extra objects to deploy
+extraObjects: []
+  # - apiVersion: cert-manager.io/v1
+  #   kind: Certificate
+  #   metadata:
+  #     name: kminion-client-cert
+  #   spec:
+  #     commonName: kminion-client


### PR DESCRIPTION
Hello,
this pr adds the possibility to provide additional objects that will be deployed alongside Kminion. A sample use-case for example to request client certificates that will then be used by Kminion to connect to Kafka.

Best regards,
Sven