### PR TITLE
connect: bump version to 4.108.0

### DIFF
--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -23,10 +23,10 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 3.2.27
+version: 3.2.28
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging
-appVersion: "4.107.2"
+appVersion: "4.108.0"
 sources:
   - https://github.com/redpanda-data/helm-charts
 annotations:
@@ -38,6 +38,6 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda
-      image: docker.redpanda.com/redpandadata/connect:4.107.2
+      image: docker.redpanda.com/redpandadata/connect:4.108.0
     - name: busybox
       image: busybox:latest

--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Connect Helm chart.
 ---
 
-![Version: 3.2.27](https://img.shields.io/badge/Version-3.2.27-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.107.2](https://img.shields.io/badge/AppVersion-4.107.2-informational?style=flat-square)
+![Version: 3.2.28](https://img.shields.io/badge/Version-3.2.28-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.108.0](https://img.shields.io/badge/AppVersion-4.108.0-informational?style=flat-square)
 
 Redpanda Connect is a high performance and resilient stream processor, able to connect various sources and sinks in a range of brokering patterns and perform hydration, enrichments, transformations and filters on payloads.
 


### PR DESCRIPTION
Automated bump of Redpanda Connect to 4.108.0.

Updates:
- `appVersion` → `4.108.0`
- Chart `version` → `3.2.28`
- ArtifactHub image tag → `connect:4.108.0`